### PR TITLE
Prevent `uploadrelease` job running on PRs

### DIFF
--- a/.github/workflows/buildcdn.yml
+++ b/.github/workflows/buildcdn.yml
@@ -46,6 +46,7 @@ jobs:
           path: dist/*
       
   uploadrelease:
+    if: github.event_name != 'pull_request'
     needs: build
     strategy:
       matrix:


### PR DESCRIPTION
This PR is an attempt at preventing the upload job from running if the action is being run on a pull request, as the jobs will always fail. And I can't believe that actually worked first time! :partying_face: 