### PR TITLE
Put the SD card content in root of zip, not subdir

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -8,7 +8,9 @@ for dir in sdcard-build/*/; do cp -r global/* "$dir/"; done
 
 cd sdcard-build
 for d in * ; do
-    zip -r ../dist/$d.zip $d/*
+    cd $d
+    zip -r ../../dist/$d.zip *
+    cd ..
 done
 cd ..
 


### PR DESCRIPTION
Prevent a subdirectory being created, so that the zip file accurately represents the state of the SD card, and hopefully allowing the flasher to work better. 