### PR TITLE
SoarETX for 2.8

### DIFF
--- a/sdcard/c480x272/WIDGETS/LibGUI/libgui.lua
+++ b/sdcard/c480x272/WIDGETS/LibGUI/libgui.lua
@@ -2,8 +2,8 @@
 -- The dynamically loadable part of the shared Lua GUI library.          --
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
--- Date:    2022-05-05                                                   --
--- Version: 1.0.1                                                        --
+-- Date:    2022-11-20                                                   --
+-- Version: 1.0.2                                                        --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
 --                                                                       --
@@ -292,6 +292,10 @@ function lib.newGUI()
             event = EVT_TOUCH_TAP
           end
         end
+				-- ETX 2.8 rc 4 bug fix
+				if scrolling and event == EVT_VIRTUAL_ENTER_LONG then
+					return
+				end
         -- If we put a finger down on a menu item and immediately slide, then we can scroll
         if event == EVT_TOUCH_SLIDE then
           if not scrolling then

--- a/sdcard/c480x272/WIDGETS/SoarETX/1/battery.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/1/battery.lua
@@ -2,8 +2,8 @@
 -- SoarETX, loadable component                                           --
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
--- Date:    2022-02-17                                                   --
--- Version: 1.0.0                                                         --
+-- Date:    2022-11-21                                                   --
+-- Version: 1.0.1                                                         --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
 --                                                                       --
@@ -21,48 +21,7 @@
 
 local widget, soarGlobals =  ...
 
--- Battery variables
-local rxBatSrc
-local rxBatNxtWarn = 0
-
-local function getWarningLevel()
-  return 0.1 * (soarGlobals.getParameter(soarGlobals.batteryParameter) + 100)
-end
-
-function widget.background()
-  local now = getTime()
-  
-  -- Receiver battery
-  if not rxBatSrc then 
-    rxBatSrc = getFieldInfo("Cels")
-    if not rxBatSrc then rxBatSrc = getFieldInfo("RxBt") end
-    if not rxBatSrc then rxBatSrc = getFieldInfo("A1") end
-    if not rxBatSrc then rxBatSrc = getFieldInfo("A2") end
-  end
-  
-  if rxBatSrc then
-    soarGlobals.battery = getValue(rxBatSrc.id)
-    
-    if type(soarGlobals.battery) == "table" then
-      for i = 2, #soarGlobals.battery do
-        soarGlobals.battery[1] = math.min(soarGlobals.battery[1], soarGlobals.battery[i])
-      end
-      soarGlobals.battery = soarGlobals.battery[1]
-    end
-  end
-
-  -- Warn about low receiver battery or Rx off
-  if now > rxBatNxtWarn and soarGlobals.battery > 0 and soarGlobals.battery < getWarningLevel() then
-    playHaptic(200, 0, 1)
-    playFile("lowbat.wav")
-    playNumber(10 * soarGlobals.battery + 0.5, 1, PREC1)
-    rxBatNxtWarn = now + 2000
-  end
-end -- background()
-
 function widget.refresh(event, touchState)
-  widget.background()
-  
   if event then
     lcd.exitFullScreen()
   end

--- a/sdcard/c480x272/WIDGETS/SoarETX/1/f3k.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/1/f3k.lua
@@ -2,8 +2,8 @@
 -- SoarETX F3K score keeper, loadable component                          --
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
--- Date:    2022-03-08                                                   --
--- Version: 1.0.0                                                        --
+-- Date:    2022-11-20                                                   --
+-- Version: 1.0.1                                                        --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
 --                                                                       --
@@ -631,7 +631,7 @@ function libGUI.widgetRefresh()
   for i = 1, taskScores do
     lcd.drawText(COL1, y, string.format("%i.", i), colors.primary1 + DBLSIZE)
     if i > #scores then
-      lcd.drawText(COL2, y, "  -   -   -", colors.primary1 + DBLSIZE)
+      lcd.drawText(COL2, y, "-  -  -", colors.primary1 + DBLSIZE)
     else
       lcd.drawTimer(COL2, y, scores[i], colors.primary1 + DBLSIZE)
     end
@@ -918,14 +918,14 @@ do -- Setup score keeper screen for F3K and Practice tasks
     
     local s = screenTask.timer(LEFT + 40, y, 60, HEIGHT, 0, nil)
     s.disabled = true
-    s.value = "  -   -   -"
+    s.value = "-  -  -"
     screenTask.scores[i] = s
 
     -- Modify timer's draw function to insert score value
     local draw = s.draw
     function s.draw(idx)
       if i > #scores then 
-        screenTask.scores[i].value = "  -   -   -"
+        screenTask.scores[i].value = "-  -  -"
       else
         screenTask.scores[i].value = scores[i]
       end
@@ -1124,7 +1124,7 @@ do -- Setup score browser screen
       lcd.drawText(x, y, j .. ".")
 
       if j > #record.scores then
-        lcd.drawText(x + 18, y, " -  -  -")
+        lcd.drawText(x + 18, y, "-  -  -")
       elseif record.unitStr == "s" then
         lcd.drawTimer(x + 18, y, record.scores[j])
       else

--- a/sdcard/c480x272/WIDGETS/SoarETX/main.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/main.lua
@@ -2,7 +2,7 @@
 -- SoarETX widget                                                        --
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
--- Date:    2022-11-21                                                   --
+-- Date:    2022-11-22                                                   --
 -- Version: 1.0.1                                                        --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
@@ -27,7 +27,6 @@ local options = {
 local soarGlobals
 
 -- Battery - moved here from battery.lua because of bugs in ETX not calling background() on topbar widgets
-local rxBatSrc
 local rxBatNxtWarn = 0
 local rxBatNxtCheck = 0
 
@@ -40,13 +39,10 @@ function rxBatCheck()
 	
 	rxBatNxtCheck = now + 100
   
-  -- Receiver battery
-  if not rxBatSrc then 
-    rxBatSrc = getFieldInfo("Cels")
-    if not rxBatSrc then rxBatSrc = getFieldInfo("RxBt") end
-    if not rxBatSrc then rxBatSrc = getFieldInfo("A1") end
-    if not rxBatSrc then rxBatSrc = getFieldInfo("A2") end
-  end
+	local rxBatSrc = getFieldInfo("Cels")
+	if not rxBatSrc then rxBatSrc = getFieldInfo("RxBt") end
+	if not rxBatSrc then rxBatSrc = getFieldInfo("A1") end
+	if not rxBatSrc then rxBatSrc = getFieldInfo("A2") end
   
   if rxBatSrc then
     soarGlobals.battery = getValue(rxBatSrc.id)


### PR DESCRIPTION
Work arounds for known Lua bugs in 2.8:

1) Top bar widgets never run `background()` - also not when another widget is in fullscreen. Therefore, the battery monitor does not run when another widget is in fullscreen.
2) `EVT_VIRTUAL_ENTER_LONG` is pushed when finger dragging on screen (should only give `EVT_TOUCH_SLIDE`).

Adjustment for wider space character for large font sizes.
