### PR TITLE
fix(SoarETX):  Replace the way to identify the radio Switches

### DIFF
--- a/sdcard/c480x272/WIDGETS/SoarETX/1/f3k_sw.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/1/f3k_sw.lua
@@ -92,9 +92,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName

--- a/sdcard/c480x272/WIDGETS/SoarETX/1/f3kre_sw.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/1/f3kre_sw.lua
@@ -91,9 +91,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+  
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName

--- a/sdcard/c480x272/WIDGETS/SoarETX/2/switch.lua
+++ b/sdcard/c480x272/WIDGETS/SoarETX/2/switch.lua
@@ -2,8 +2,9 @@
 -- SoarETX F3K switch setup, loadable component                          --
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
--- Date:    2022-02-14                                                   --
--- Version: 1.0.0                                                        --
+-- Improvements: Frankie Arzu                                            --
+-- Date:    2024-04-7                                                    --
+-- Version: 1.2.1                                                        --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
 --                                                                       --
@@ -133,9 +134,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+  
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName

--- a/sdcard/c480x320/WIDGETS/SoarETX/1/f3k_sw.lua
+++ b/sdcard/c480x320/WIDGETS/SoarETX/1/f3k_sw.lua
@@ -92,9 +92,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName

--- a/sdcard/c480x320/WIDGETS/SoarETX/1/f3kre_sw.lua
+++ b/sdcard/c480x320/WIDGETS/SoarETX/1/f3kre_sw.lua
@@ -91,9 +91,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+  
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName

--- a/sdcard/c480x320/WIDGETS/SoarETX/2/switch.lua
+++ b/sdcard/c480x320/WIDGETS/SoarETX/2/switch.lua
@@ -3,8 +3,8 @@
 --                                                                       --
 -- Author:  Jesper Frickmann                                             --
 -- Improvements: Frankie Arzu                                            --
--- Date:    2024-01-15                                                   --
--- Version: 1.2.0                                                        --
+-- Date:    2024-04-7                                                    --
+-- Version: 1.2.1                                                        --
 --                                                                       --
 -- Copyright (C) EdgeTX                                                  --
 --                                                                       --
@@ -134,9 +134,9 @@ local function init()
   -- Build lists of physical switch position indices and names
   local swIndices = { }
   local swNames = { }
-  local MAX_SW = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
-  for swIdx, swName in switches(-MAX_SW, MAX_SW) do
-    if swIdx ~= 0 then
+  
+  for swIdx, swName in switches() do
+    if string.find(swName,"^!?S[A-H][+-]?") then
       i = #swIndices + 1
       swIndices[i] = swIdx
       swNames[i] = swName


### PR DESCRIPTION
Fixes #142
The way to find the switches worked in 2.9.4, but not in 2.10.  Fixing it to a way that works for both.

The correction is for both version 1 (backward compatibility), and new v2.

The code  for firmware 2.9.x (and before) was looking for a "trim" with name "Rl" to identify the "last" switch.. looks like is no longer there in 2.10.

Change the code to identify the switches using a pattern.