### PR TITLE
fix(wizard): respect radio default channel order when deleting rudder input

### DIFF
--- a/sdcard/c480x272/TEMPLATES/1.Wizard/3.Wing.lua
+++ b/sdcard/c480x272/TEMPLATES/1.Wizard/3.Wing.lua
@@ -442,7 +442,7 @@ local function createModel(event)
     lcd.drawBitmap(BackgroundImg, 0, 0)
     lcd.drawBitmap(ImgSummary, 300, 60)
     model.defaultInputs()
-    model.deleteInput(3, 0) -- delete rudder
+    model.deleteInput(defaultChannel(STICK_NUMBER_RUD), 0) -- delete rudder
     model.deleteMixes()
 
     -- expo


### PR DESCRIPTION
This fixes #190 