### PR TITLE
fix: make BattAnalog widget work on nightly builds

### DIFF
--- a/sdcard/c480x272/WIDGETS/BattAnalog/main.lua
+++ b/sdcard/c480x272/WIDGETS/BattAnalog/main.lua
@@ -89,7 +89,7 @@ local function update(wgt, options)
 
 
     local ver, radio, maj, minor, rev, osname = getVersion()
-    wgt.is_valid_ver = (maj == 2 and minor >= 11)
+    wgt.is_valid_ver = (maj == 2 and minor >= 11) or (maj > 2)
     if wgt.is_valid_ver==false then
         local lytIvalidVer = {
             {

--- a/sdcard/c480x320/WIDGETS/BattAnalog/main.lua
+++ b/sdcard/c480x320/WIDGETS/BattAnalog/main.lua
@@ -89,7 +89,7 @@ local function update(wgt, options)
 
 
     local ver, radio, maj, minor, rev, osname = getVersion()
-    wgt.is_valid_ver = (maj == 2 and minor >= 11)
+    wgt.is_valid_ver = (maj == 2 and minor >= 11) or (maj > 2)
     if wgt.is_valid_ver==false then
         local lytIvalidVer = {
             {


### PR DESCRIPTION
currently, the BattAnalog widget is not working on nightly builds because of a missing version check. 