### PR TITLE
fix(BattAnalog): misalignment when selecting 8/10/12 cells, min value not working, add "cell" sensor

### DIFF
--- a/sdcard/c480x272/WIDGETS/BattAnalog/main.lua
+++ b/sdcard/c480x272/WIDGETS/BattAnalog/main.lua
@@ -34,24 +34,22 @@
 
 -- Widget to display the levels of Lipo battery from single analog source
 -- Author : Offer Shmuely
--- Date: 2021-2024
+-- Date: 2021-2025
 local app_name = "BattAnalog"
-local app_ver = "1.2"
-
-local CELL_DETECTION_TIME = 8
-local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "tcd")(m_log,app_name)
-local DEFAULT_SOURCE = lib_sensors.findSourceId( {"cell","VFAS","RxBt","A1", "A2"})
-local useLvgl = true
+local app_ver = "1.5"
 
 local _options = {
-    {"sensor"            , SOURCE, DEFAULT_SOURCE },
+    {"sensor"            , SOURCE, "RxBt" },
+    -- should work soon {"sensor", SOURCE, {"cell","VFAS","RxBt","A1", "A2"} },
     {"batt_type"         , CHOICE, 1 , {"LiPo", "LiPo-HV (high voltage)", "Li-Ion"} },
-    {"cbCellCount"       , CHOICE, 1 , {"Auto Detection", "1 cell", "2 cell", "3 cell", "4 cell", "5 cell", "6 cell", "8 cell", "10 cell", "12 cell", "14 cell"} },
+    {"cbCellCount"       , CHOICE, 1 , {"Auto Detection", "1 cell", "2 cell", "3 cell", "4 cell", "5 cell", "6 cell", "7 cell","8 cell", "10 cell", "12 cell", "14 cell"} },
     {"isTotalVoltage"    , BOOL  , 0      }, -- 0=Show as average Lipo cell level, 1=show the total voltage (voltage as is)
     {"color"             , COLOR , YELLOW },
+    {"isTelemCellV"      , BOOL  , 0},
+    -- {"isTelemCellPerc"   , BOOL  , 0},
 }
 
-local function translate(nam)
+local function translate(name)
     local translations = {
         sensor = "Voltage Sensor",
         color = "Text Color",
@@ -59,15 +57,18 @@ local function translate(nam)
         batt_type="Battery Type",
         cellCount = "Cell Count (0=auto)",
         cbCellCount = "Cell Count",
+        isTelemCellV = "Generate Telemetry Cell",
+        isTelemCellPerc = "Generate Telemetry Cell%",
+
     }
-    return translations[nam]
+    return translations[name]
 end
 
 local function create(zone, options)
     -- imports
     local m_log = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")(app_name, "/WIDGETS/" .. app_name)
     local wgt = loadScript("/WIDGETS/" .. app_name .. "/logic.lua")(m_log)
-    wgt.tools = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")(m_log, app_name, useLvgl)
+    wgt.tools = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")(m_log, app_name, true)
     wgt.zone = zone
     wgt.options = options
     wgt.m_log = m_log
@@ -83,13 +84,11 @@ end
 local function update(wgt, options)
     wgt.options = options
 
-    wgt.batt_height = wgt.zone.h --???
+    wgt.batt_height = wgt.zone.h
     wgt.batt_width = wgt.zone.w
-    -- wgt.log("batt_11  width: " .. wgt.batt_width .. ", height: " .. wgt.batt_height)
-
 
     local ver, radio, maj, minor, rev, osname = getVersion()
-    wgt.is_valid_ver = (maj == 2 and minor >= 11)
+    wgt.is_valid_ver = (maj == 2 and minor >= 11) or (maj > 2)
     if wgt.is_valid_ver==false then
         local lytIvalidVer = {
             {
@@ -118,6 +117,7 @@ local function getDxByStick(stk)
 end
 
 local function refresh(wgt, event, touchState)
+    wgt.background()
 
     wgt.refresh(event, touchState)
 end
@@ -130,5 +130,5 @@ return {
     background = background,
     refresh = refresh,
     translate=translate,
-    useLvgl = true
+    useLvgl=true
 }

--- a/sdcard/c480x272/WIDGETS/BattAnalog/ui_lvgl.lua
+++ b/sdcard/c480x272/WIDGETS/BattAnalog/ui_lvgl.lua
@@ -268,32 +268,11 @@ local function layoutZoneNormal()
 end
 
 function wgt.refresh(event, touchState)
-    wgt.tools.detectResetEvent(wgt, wgt.onTelemetryResetEvent)
-    wgt.calculateBatteryData()
-
-    if wgt.isDataAvailable then
-        wgt.text_color = wgt.options.color
-    else
-        wgt.text_color = GREY
-    end
+    wgt.text_color = (wgt.isDataAvailable) and wgt.options.color or GREY
 end
 
 function wgt.update_ui()
     lvgl.clear()
-
-    -- local text = "TEST"
-    -- local font_size = FONT_38
-    -- local ts_w, ts_h, v_offset = wgt.tools.lcdSizeTextFixed(text, font_size)
-    -- local myString = string.format("%sx%s (%s,%s)", wgt.zone.w, wgt.zone.h, wgt.zone.x, wgt.zone.y)
-    -- lytZone = {
-        -- {type=LVGL_DEF.type.RECTANGLE, x=0, y=0, w=ts_w, h=ts_h, color=RED, filled=false},
-    --     {type=LVGL_DEF.type.LABEL, text="TEST", x=0, y=0 + v_offset, font=font_size, color=BLACK},
-        -- show spaces
-        -- {type=LVGL_DEF.type.RECTANGLE, x=wgt.zone.x, y=wgt.zone.y, w=wgt.zone.w, h=wgt.zone.h, color=BLUE, filled=false, thickness=space},
-        -- show zone size
-        -- {type=LVGL_DEF.type.LABEL, text=myString, x=wgt.zone.x+wgt.zone.w/2, y=wgt.zone.y+wgt.zone.h/2, font=FONT_6, color=BLACK},
-    -- }
-    -- lvgl.build(lytZone)
 
     if wgt.zone.w <  75 and wgt.zone.h < 45 then
         layoutZoneTopbar()


### PR DESCRIPTION
- widget can now generate "cell" telemetry sensor, so logical-switch & sound can be apply with 3.6-4.2 values instead of full voltage 
- fix: when selecting cells, the min value is not working
- fix: when selecting 8/10/12 cells, there is misalignment
- add support for 7 cells
