### PR TITLE
feat(bw128): support more switches for some handsets in multi wizard

### DIFF
--- a/sdcard/bw128x64/SCRIPTS/WIZARD/multi.lua
+++ b/sdcard/bw128x64/SCRIPTS/WIZARD/multi.lua
@@ -31,7 +31,6 @@ local edit = false
 local field = 0
 local fieldsMax = 0
 local comboBoxMode = 0 -- Scrap variable
-local validSwitch = {}
 
 -- Model settings
 local thrCH1 = 0
@@ -115,7 +114,7 @@ local function navigate(event, fieldMax, prevPage, nextPage)
 end
 
 local function getFieldFlags(position)
-  flags = 0
+  local flags = 0
   if field == position then
     flags = INVERS
     if edit then
@@ -126,8 +125,8 @@ local function getFieldFlags(position)
 end
 
 local function channelIncDec(event, value)
-  if not edit and event==EVT_VIRTUAL_MENU then
-    servoPage = value
+  if not edit and event == EVT_VIRTUAL_MENU then
+    -- servoPage = value
     dirty = true
   else
     value = valueIncDec(event, value, 0, 15)
@@ -153,8 +152,8 @@ local function switchValueIncDec(event, value, min, max)
 end
 
 local function switchIncDec(event, value)
-  if not edit and event== EVT_VIRTUAL_MENU then
-    servoPage = value
+  if not edit and event == EVT_VIRTUAL_MENU then
+    -- servoPage = value
     dirty = true
   else
     value = switchValueIncDec(event, value, 1, #switches)
@@ -169,10 +168,37 @@ local function init()
   yawCH1 = defaultChannel(0)
   pitchCH1 = defaultChannel(1)
   local ver, radio, maj, minor, rev = getVersion()
-  if string.match(radio, "x7") then
+
+  -- FrSky Taranis QX7 & QX7 ACCESS
+  if string.match(radio, "x7") or string.match(radio, "x7access") then
     switches = {"SA", "SB", "SC", "SD", "SF", "SH"}
-  elseif string.match(radio, "tx12") then
+  -- FrSky Taranis X9 Lite & X9 Lite S
+  elseif (string.match(radio, "x9lite") or string.match(radio, "x9lites")) then
+    switches = {"SA", "SB", "SC", "SD", "SE", "SF", "SG"}
+  -- Jumper T12
+  elseif string.match(radio, "t12") then
+    switches = {"SA", "SB", "SC", "SD", "SG", "SH"}
+  -- Radiomaster GX12
+  elseif string.match(radio, "gx12") then
+    switches = {"SA", "SB", "SC", "SD", "SE", "SF", "SG", "SH"}
+  -- Radiomaster Pocket
+  elseif string.match(radio, "pocket") then
+    switches = {"SA", "SB", "SC", "SD", "SE"}
+  -- HelloRadioSky V14
+  -- Jumper T12 MAX & Jumper T14
+  -- Radiomaster TX12 & TX12 MKII
+  elseif (string.match(radio,"v14") or string.match(radio, "t12max") or string.match(radio, "t14")
+          or string.match(radio, "tx12") or string.match(radio, "tx12mk2")) then
     switches = {"SA", "SB", "SC", "SD", "SE", "SF"}
+  -- Radiomaster Zorro
+  elseif string.match(radio, "zorro") then
+    switches = {"SB", "SC", "SE", "SF", "SG", "SH"}
+  -- BETAFPV LiteRadio 3 Pro
+  -- FrSky Taranis X-Lite
+  -- iFlight Commando 8
+  -- Radiomaster Boxer & T8
+  -- Jumper T20, Bumblebee, Jumper T-Lite, T-Pro, T-Pro V2 & T-Pro S
+  -- Default
   else
     switches = {"SA", "SB", "SC", "SD"}
   end
@@ -427,10 +453,10 @@ local function run(event)
     pitchMenu(event)
   elseif page == ARM_PAGE then
     armMenu(event)
-  elseif page == BEEPER_PAGE then
-    beeperMenu(event)
   elseif page == MODE_PAGE then
     modeMenu(event)
+  elseif page == BEEPER_PAGE then
+    beeperMenu(event)
   elseif page == CONFIRMATION_PAGE then
     return confirmationMenu(event)
   end

--- a/sdcard/bw128x64/SCRIPTS/WIZARD/wizard.lua
+++ b/sdcard/bw128x64/SCRIPTS/WIZARD/wizard.lua
@@ -28,7 +28,7 @@ local function fieldIncDec(event, value, max)
   elseif event == EVT_VIRTUAL_INC or event == EVT_VIRTUAL_INC_REPT then
     value = (value + max + 3)
   end
-  value = (value % (max+2))
+  value = (value % (max + 2))
   return value
 end
 
@@ -44,12 +44,11 @@ end
 local function drawModelChoiceMenu()
   lcd.clear()
   lcd.drawScreenTitle("Select model type", 0, 0)
-    lcd.drawText( 20, 20, "Plane")
-    lcd.drawText( 78, 20, "Delta")
-    lcd.drawText( 20, 40, "Multi")
-    lcd.drawText( 78, 40, "Heli")
+  lcd.drawText( 20, 20, "Plane")
+  lcd.drawText( 78, 20, "Delta")
+  lcd.drawText( 20, 40, "Multi")
+  lcd.drawText( 78, 40, "Heli")
   modelTypeSurround(modelType)
-  fieldsMax = 0
 end
 
 local function modelTypeMenu(event)


### PR DESCRIPTION
Using a Radiomaster GX12 I noticed that only SA->SD were assignable while using the quick model multicopter setup wizard. I went through a bunch of hardware manuals to figure out which switches were available on supported controllers. Tested a few different models in the simulator.