### PR TITLE
fix(libgui): update c480x320 last switch detection to work with 2.11

### DIFF
--- a/sdcard/c480x320/WIDGETS/LibGUI/loadable.lua
+++ b/sdcard/c480x320/WIDGETS/LibGUI/loadable.lua
@@ -51,6 +51,17 @@ local gui = libGUI.newGUI()
 -- Make a minimize button from a custom element
 local custom = gui.custom({ }, LCD_W - 34, 6, 28, 28)
 
+local function getLastSwitchIndex()
+    local lastSwitch
+    for switchIndex, switchName in switches(1, SWSRC_LAST) do
+        if string.find(switchName, "^!?S[A-R][+-]?") then
+            lastSwitch = switchIndex
+        end
+    end
+    return lastSwitch
+end
+
+
 function custom.draw(focused)
   lcd.drawRectangle(LCD_W - 34, 6, 28, 28, libGUI.colors.primary2)
   lcd.drawFilledRectangle(LCD_W - 30, 19, 20, 3, libGUI.colors.primary2)
@@ -92,7 +103,7 @@ labelDropDown = subGUI.label(0, 2 * ROW, 2 * WIDTH, HEIGHT, "")
 
 local dropDownIndices = { }
 local dropDownItems = { }
-local lastSwitch = getSwitchIndex(CHAR_TRIM .. "Rl") - 1
+local lastSwitch = getLastSwitchIndex()
 
 for i, s in switches(-lastSwitch, lastSwitch) do
   if i ~= 0 then 


### PR DESCRIPTION
When running the LibGUI demo on my TX15 (which uses a C480x320 display), I encountered an error related to the last switch detection. After reviewing PR #140 , I applied a similar fix, and it resolved the issue.