### PR TITLE
Load script with debugging should use "btd" instead of "tcd" - v2.11

### DIFF
--- a/sdcard/c320x480/WIDGETS/Flights/main.lua
+++ b/sdcard/c320x480/WIDGETS/Flights/main.lua
@@ -146,7 +146,7 @@ local function create(zone, options)
     --wgt.options.use_days = wgt.options.use_days % 2 -- modulo due to bug that cause the value to be other than 0|1
 
     -- imports
-    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
+    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
     wgt.tools = wgt.ToolsClass(app_name)
 
     update(wgt, options)

--- a/sdcard/c480x272/SCRIPTS/PRESETS/engine/main.lua
+++ b/sdcard/c480x272/SCRIPTS/PRESETS/engine/main.lua
@@ -31,9 +31,9 @@ local app_name = "PresetsLoader"
 local script_folder = "/SCRIPTS/PRESETS/engine/"
 --chdir(script_folder)
 
-local m_log =  loadScript(script_folder .. "lib_log", "tcd")(app_name, script_folder)
-local m_utils = loadScript(script_folder .. "lib_utils", "tcd")(m_log, app_name, script_folder)
-local m_libgui =  loadScript(script_folder .. "libgui", "tcd")()
+local m_log =  loadScript(script_folder .. "lib_log", "btd")(app_name, script_folder)
+local m_utils = loadScript(script_folder .. "lib_utils", "btd")(m_log, app_name, script_folder)
+local m_libgui =  loadScript(script_folder .. "libgui", "btd")()
 
 local preset_list = {
     about="---"
@@ -221,7 +221,7 @@ local function state_PRESET_OPTIONS_INIT()
 
     -- validate module exist
     local script_name = "/SCRIPTS/PRESETS/scripts/" .. dd_preset_folder_name .. "/main.lua"
-    local code_chunk = loadScript(script_name, "tcd")
+    local code_chunk = loadScript(script_name, "btd")
     if code_chunk == nil then
         error_desc = "File not found: " .. script_name
         return

--- a/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/libgui4/libgui4.lua
+++ b/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/libgui4/libgui4.lua
@@ -24,7 +24,7 @@ for ctl_name in dir(libgui_dir) do
     local file_name_short = string.match(ctl_name, "^(ctl_.+).lua$")
     if file_name_short ~= nil then
         M.log("loadControl(%s)", ctl_name)
-        M.newCtl[file_name_short] = assert(loadScript(M.libgui_dir .. "/" .. ctl_name, "tcd"))()
+        M.newCtl[file_name_short] = assert(loadScript(M.libgui_dir .. "/" .. ctl_name, "btd"))()
         M.log("ctl_file: %s, flie_name_short: %s", ctl_name, file_name_short)
     end
 end

--- a/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/main.lua
+++ b/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/main.lua
@@ -37,7 +37,7 @@ local error_desc = nil
 local script_folder = "/SCRIPTS/TOOLS/FlightsHistory/"
 
 local function my_load_script(file_name, ...)
-    local code_chunk = assert(loadScript(script_folder .. file_name, "tcd"))
+    local code_chunk = assert(loadScript(script_folder .. file_name, "btd"))
     -- print(string.format("%s - loading, num args: %d", file_name, #{...}))
     return code_chunk(...)
 end

--- a/sdcard/c480x272/WIDGETS/BattCheck/main.lua
+++ b/sdcard/c480x272/WIDGETS/BattCheck/main.lua
@@ -22,7 +22,7 @@
 local app_name = "BattCheck"
 local app_ver = "0.9"
 
-local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "tcd")(m_log,app_name)
+local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "btd")(m_log,app_name)
 local DEFAULT_SOURCE = lib_sensors.findSourceId( {"Cels"})
 
 local _options = {

--- a/sdcard/c480x272/WIDGETS/Flights/app.lua
+++ b/sdcard/c480x272/WIDGETS/Flights/app.lua
@@ -73,7 +73,7 @@ local use_flights_history = 1                -- 0=do not write flights-history, 
 
 -- imports
 local img = bitmap.open("/WIDGETS/" .. app_name .. "/logo.png")
-local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")
+local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")
 local m_log = LibLogClass(app_name, "/WIDGETS/" .. app_name)
 
 -- better font size names
@@ -162,12 +162,12 @@ local function create(zone, options)
     --wgt.options.use_days = wgt.options.use_days % 2 -- modulo due to bug that cause the value to be other than 0|1
 
     -- imports
-    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
+    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
     wgt.tools = wgt.ToolsClass(m_log, app_name)
 
-    wgt.FlightsHistoryClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_history.lua", "tcd")
+    wgt.FlightsHistoryClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_history.lua", "btd")
     wgt.flightHistory = wgt.FlightsHistoryClass(m_log, app_name)
-    wgt.FlightsCountClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_count.lua", "tcd")
+    wgt.FlightsCountClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_count.lua", "btd")
     wgt.flightCountHWriter = wgt.FlightsCountClass(m_log, app_name, "/flights-count.csv")
 
     update(wgt, options)

--- a/sdcard/c480x272/WIDGETS/Flights/main.lua
+++ b/sdcard/c480x272/WIDGETS/Flights/main.lua
@@ -50,7 +50,7 @@ end
 
 local function create(zone, options)
     -- print(string.format("1111 Flights create: %s", name))
-    tool = assert(loadScript("/WIDGETS/"..app_name.."/app.lua", "tcd"))()
+    tool = assert(loadScript("/WIDGETS/"..app_name.."/app.lua", "btd"))()
     return tool.create(zone, options)
 end
 local function update(wgt, options) return tool.update(wgt, options) end

--- a/sdcard/c480x272/WIDGETS/GaugeRotary/main.lua
+++ b/sdcard/c480x272/WIDGETS/GaugeRotary/main.lua
@@ -72,7 +72,7 @@ local FONT_8 = 0 -- Default 8px
 local FONT_6 = SMLSIZE -- 6px
 
 
-local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "tcd")(m_log,app_name)
+local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "btd")(m_log,app_name)
 local DEFAULT_SOURCE = lib_sensors.findSourceId( {"RQLY", "VFR", "cell","cels","RSSI","RxBt"})
 
 local _options = {
@@ -86,9 +86,9 @@ local _options = {
 }
 
 -- imports
-local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")
-local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
-local GaugeClass = loadScript("/WIDGETS/" .. app_name .. "/gauge_core.lua", "tcd")
+local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")
+local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
+local GaugeClass = loadScript("/WIDGETS/" .. app_name .. "/gauge_core.lua", "btd")
 
 local m_log = LibLogClass(app_name, "/WIDGETS/" .. app_name)
 

--- a/sdcard/c480x272/WIDGETS/MicroValues/app.lua
+++ b/sdcard/c480x272/WIDGETS/MicroValues/app.lua
@@ -31,8 +31,8 @@ local app_ver = "1.2"
 
 
 -- imports
-local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")
-local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
+local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")
+local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
 
 local m_log = LibLogClass(app_name, "/WIDGETS/" .. app_name)
 

--- a/sdcard/c480x272/WIDGETS/MicroValues/main.lua
+++ b/sdcard/c480x272/WIDGETS/MicroValues/main.lua
@@ -26,7 +26,7 @@ end
 
 local tool = nil
 local function create(zone, options)
-    tool = assert(loadScript("/WIDGETS/" .. app_name .. "/app.lua", "tcd"))()
+    tool = assert(loadScript("/WIDGETS/" .. app_name .. "/app.lua", "btd"))()
     return tool.create(zone, options)
 end
 local function update(wgt, options) return tool.update(wgt, options) end

--- a/sdcard/c480x320/WIDGETS/BattAnalog/main.lua
+++ b/sdcard/c480x320/WIDGETS/BattAnalog/main.lua
@@ -39,7 +39,7 @@ local app_name = "BattAnalog"
 local app_ver = "1.2"
 
 local CELL_DETECTION_TIME = 8
-local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "tcd")(m_log,app_name)
+local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "btd")(m_log,app_name)
 local DEFAULT_SOURCE = lib_sensors.findSourceId( {"cell","VFAS","RxBt","A1", "A2"})
 local useLvgl = true
 
@@ -65,9 +65,9 @@ end
 
 local function create(zone, options)
     -- imports
-    local m_log = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")(app_name, "/WIDGETS/" .. app_name)
+    local m_log = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")(app_name, "/WIDGETS/" .. app_name)
     local wgt = loadScript("/WIDGETS/" .. app_name .. "/logic.lua")(m_log)
-    wgt.tools = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")(m_log, app_name, useLvgl)
+    wgt.tools = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")(m_log, app_name, useLvgl)
     wgt.zone = zone
     wgt.options = options
     wgt.m_log = m_log

--- a/sdcard/c480x320/WIDGETS/Flights/app.lua
+++ b/sdcard/c480x320/WIDGETS/Flights/app.lua
@@ -73,7 +73,7 @@ local use_flights_history = 1                -- 0=do not write flights-history, 
 
 -- imports
 local img = bitmap.open("/WIDGETS/" .. app_name .. "/logo.png")
-local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")
+local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")
 local m_log = LibLogClass(app_name, "/WIDGETS/" .. app_name)
 
 -- better font size names
@@ -162,12 +162,12 @@ local function create(zone, options)
     --wgt.options.use_days = wgt.options.use_days % 2 -- modulo due to bug that cause the value to be other than 0|1
 
     -- imports
-    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
+    wgt.ToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
     wgt.tools = wgt.ToolsClass(m_log, app_name)
 
-    wgt.FlightsHistoryClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_history.lua", "tcd")
+    wgt.FlightsHistoryClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_history.lua", "btd")
     wgt.flightHistory = wgt.FlightsHistoryClass(m_log, app_name)
-    wgt.FlightsCountClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_count.lua", "tcd")
+    wgt.FlightsCountClass = loadScript("/WIDGETS/" .. app_name .. "/lib_flights_count.lua", "btd")
     wgt.flightCountHWriter = wgt.FlightsCountClass(m_log, app_name, "/flights-count.csv")
 
     update(wgt, options)

--- a/sdcard/c480x320/WIDGETS/Flights/main.lua
+++ b/sdcard/c480x320/WIDGETS/Flights/main.lua
@@ -50,7 +50,7 @@ end
 
 local function create(zone, options)
     -- print(string.format("1111 Flights create: %s", name))
-    tool = assert(loadScript("/WIDGETS/"..app_name.."/app.lua", "tcd"))()
+    tool = assert(loadScript("/WIDGETS/"..app_name.."/app.lua", "btd"))()
     return tool.create(zone, options)
 end
 local function update(wgt, options) return tool.update(wgt, options) end

--- a/sdcard/c480x320/WIDGETS/GaugeRotary/main.lua
+++ b/sdcard/c480x320/WIDGETS/GaugeRotary/main.lua
@@ -72,7 +72,7 @@ local FONT_8 = 0 -- Default 8px
 local FONT_6 = SMLSIZE -- 6px
 
 
-local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "tcd")(m_log,app_name)
+local lib_sensors = loadScript("/WIDGETS/" .. app_name .. "/lib_sensors.lua", "btd")(m_log,app_name)
 local DEFAULT_SOURCE = lib_sensors.findSourceId( {"RQLY", "VFR", "cell","cels","RSSI","RxBt"})
 
 local _options = {
@@ -86,9 +86,9 @@ local _options = {
 }
 
 -- imports
-local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "tcd")
-local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "tcd")
-local GaugeClass = loadScript("/WIDGETS/" .. app_name .. "/gauge_core.lua", "tcd")
+local LibLogClass = loadScript("/WIDGETS/" .. app_name .. "/lib_log.lua", "btd")
+local LibWidgetToolsClass = loadScript("/WIDGETS/" .. app_name .. "/lib_widget_tools.lua", "btd")
+local GaugeClass = loadScript("/WIDGETS/" .. app_name .. "/gauge_core.lua", "btd")
 
 local m_log = LibLogClass(app_name, "/WIDGETS/" .. app_name)
 


### PR DESCRIPTION
Loading script using "tcd" flag will always recompile the LUA script whenever it loads.  To enable debugging information properly included in LUA scripts, "btd" flag should be used instead.

As per the documentation of the luaLoadScripts:
`
    "b" only binary.
`
`
    "t" only text.
`
`
    "T" (default on simulator) prefer text but load binary if that is the only version available.
`
`
    "bt" (default on radio) either binary or text, whichever is newer (binary preferred when timestamps are equal).
`
`
    Add "x" to avoid automatic compilation of source file to .luac version.
      Eg: "tx", "bx", or "btx".
`
`
    Add "c" to force compilation of source file to .luac version (even if existing version is newer than source file).
      Eg: "tc" or "btc" (forces "t", overrides "x").
`
`
    Add "d" to keep extra debug info in the compiled binary.
      Eg: "td", "btd", or "tcd" (no effect with just "b" or with "x").
`

"btd" means it will load binary and text and will include debugging information in the compiled binary.
"tcd" means it will load text only and will force compile the binary upon loading with debugging information included.