### PR TITLE
ci: migrate release workflow off unmaintained action and update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/buildcdn.yml
+++ b/.github/workflows/buildcdn.yml
@@ -38,29 +38,46 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build-artifact
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
           name: sdcard-latest
           path: .
-      - name: Deploy release
-        uses: crowbarmaster/GH-Automatic-Releases@latest
+      - name: Update latest tag
         if: github.ref == 'refs/heads/master'
+        run: |
+          git tag -f latest
+          git push -f origin latest
+      - name: Delete previous latest release
+        if: github.ref == 'refs/heads/master'
+        run: gh release delete latest --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy latest prerelease
+        if: github.ref == 'refs/heads/master'
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          tag_name: latest
+          target_commitish: ${{ github.sha }}
           prerelease: true
-          title: "Latest"
+          name: Latest
+          generate_release_notes: true
           files: |
             dist/*
             sdcard.json
       - name: Auto Create Draft Release
-        uses: crowbarmaster/GH-Automatic-Releases@latest
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.event.ref, 'refs/tags/v')
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: ${{ github.ref_name }}
           draft: true
           prerelease: false
+          generate_release_notes: true
           files: |
             dist/*
             sdcard.json

--- a/.github/workflows/buildcdn.yml
+++ b/.github/workflows/buildcdn.yml
@@ -21,13 +21,13 @@ jobs:
   build-artifact:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Generate ZIPs
         run: |
           chmod +x generate.sh
           ./generate.sh
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdcard-latest
           path: |
@@ -39,7 +39,7 @@ jobs:
     needs: build-artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: sdcard-latest
           path: .


### PR DESCRIPTION
Modernise the release workflow in buildcdn.yml:
- Update core GitHub Actions to current major versions that run on Node 24-compatible runtimes.
- Replace unmaintained crowbarmaster/GH-Automatic-Releases with a maintained release flow based on softprops/action-gh-release and gh CLI.