### PR TITLE
feat(widget): add trainer link status

### DIFF
--- a/sdcard/color/WIDGETS/Trainer/README.md
+++ b/sdcard/color/WIDGETS/Trainer/README.md
@@ -1,0 +1,23 @@
+# Trainer widget
+
+The Trainer widget shows the instructor radio's trainer-link state and whether
+student control is requested.
+
+It distinguishes between a link that has never connected and one that was
+lost after connecting. Enabled model special functions using the **Trainer**
+action are discovered automatically, so the widget does not need a duplicate
+control-switch setting.
+
+The widget supports top-bar, compact, medium, and large color-screen zones. It
+uses EdgeTX's built-in trainer glyph and drawing primitives, with no bitmap
+assets.
+
+## States
+
+- **Waiting**: a trainer link has not connected.
+- **Connected**: the link is ready and the instructor has control.
+- **Student control**: the link is connected and a Trainer special function is active.
+- **Link lost**: a previously connected trainer link disconnected.
+- **No link**: student control is requested without a valid trainer link.
+
+Requires EdgeTX 2.9 or later for `getTrainerStatus()`.

--- a/sdcard/color/WIDGETS/Trainer/logic.lua
+++ b/sdcard/color/WIDGETS/Trainer/logic.lua
@@ -1,0 +1,149 @@
+--
+-- Copyright (C) EdgeTX
+--
+-- License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+--
+
+local M = {}
+
+local TRAINER_NOT_CONNECTED = 0
+local TRAINER_CONNECTED = 1
+local TRAINER_DISCONNECTED = 2
+local TRAINER_RECONNECTED = 3
+
+local states = {
+    waiting = {
+        label = "WAITING",
+        short = "WAIT",
+        detail = "No trainer link",
+        link = "Not connected",
+        control = "Instructor",
+        color = "neutral",
+    },
+    waiting_requested = {
+        label = "NO LINK",
+        short = "NO LINK",
+        detail = "Student control requested",
+        link = "Not connected",
+        control = "Requested",
+        color = "warning",
+    },
+    connected = {
+        label = "CONNECTED",
+        short = "LINK",
+        detail = "Trainer link ready",
+        link = "Connected",
+        control = "Instructor",
+        color = "connected",
+    },
+    reconnected = {
+        label = "RECONNECTED",
+        short = "BACK",
+        detail = "Trainer link restored",
+        link = "Connected",
+        control = "Instructor",
+        color = "connected",
+    },
+    active = {
+        label = "STUDENT CONTROL",
+        short = "LIVE",
+        detail = "Trainer input is active",
+        link = "Connected",
+        control = "Student",
+        color = "active",
+    },
+    lost = {
+        label = "LINK LOST",
+        short = "LOST",
+        detail = "Trainer was disconnected",
+        link = "Lost",
+        control = "Instructor",
+        color = "warning",
+    },
+    lost_requested = {
+        label = "LINK LOST",
+        short = "LOST",
+        detail = "Student control requested",
+        link = "Lost",
+        control = "Requested",
+        color = "warning",
+    },
+    unknown = {
+        label = "UNKNOWN",
+        short = "?",
+        detail = "Trainer state unavailable",
+        link = "Unknown",
+        control = "Instructor",
+        color = "neutral",
+    },
+}
+
+function M.findTrainerSwitches(getCustomFunction, trainerFunction)
+    local switches = {}
+    local seen = {}
+
+    for index = 0, 63 do
+        local customFunction = getCustomFunction(index)
+        if customFunction == nil then
+            break
+        end
+
+        local enabled = customFunction.active == true or customFunction.active == 1
+        local switch = customFunction.switch or 0
+        if enabled and customFunction.func == trainerFunction and switch ~= 0 and not seen[switch] then
+            switches[#switches + 1] = switch
+            seen[switch] = true
+        end
+    end
+
+    return switches
+end
+
+function M.isControlRequested(switches, getSwitchValue)
+    for index = 1, #switches do
+        if getSwitchValue(switches[index]) == true then
+            return true
+        end
+    end
+
+    return false
+end
+
+function M.classify(status, controlRequested, showReconnected)
+    local key
+
+    if status == TRAINER_CONNECTED or status == TRAINER_RECONNECTED then
+        if controlRequested then
+            key = "active"
+        elseif status == TRAINER_RECONNECTED and showReconnected then
+            key = "reconnected"
+        else
+            key = "connected"
+        end
+    elseif status == TRAINER_DISCONNECTED then
+        key = controlRequested and "lost_requested" or "lost"
+    elseif status == TRAINER_NOT_CONNECTED then
+        key = controlRequested and "waiting_requested" or "waiting"
+    else
+        key = "unknown"
+    end
+
+    return key, states[key]
+end
+
+function M.layoutForZone(zone)
+    local width = zone and zone.w or 0
+    local height = zone and zone.h or 0
+
+    if width < 120 or height <= 45 then
+        return "tiny"
+    elseif height <= 70 then
+        return "compact"
+    elseif width < 240 or height < 130 then
+        return "medium"
+    end
+
+    return "large"
+end
+
+return M

--- a/sdcard/color/WIDGETS/Trainer/main.lua
+++ b/sdcard/color/WIDGETS/Trainer/main.lua
@@ -1,0 +1,245 @@
+--
+-- Copyright (C) EdgeTX
+--
+-- License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+--
+
+local appName = "Trainer"
+local logic = assert(loadScript("/WIDGETS/" .. appName .. "/logic.lua", "btd"))()
+
+local RESCAN_INTERVAL = 100
+local RECONNECTED_DURATION = 200
+
+local options = {
+    { "Connected", COLOR, COLOR_THEME_PRIMARY2 },
+    { "Active", COLOR, COLOR_THEME_ACTIVE },
+    { "Warning", COLOR, COLOR_THEME_WARNING },
+    { "Neutral", COLOR, COLOR_THEME_DISABLED },
+    { "Text", COLOR, COLOR_THEME_PRIMARY1 },
+}
+
+local function translate(name)
+    local translations = {
+        Connected = "Connected color",
+        Active = "Student control color",
+        Warning = "Link warning color",
+        Neutral = "Waiting color",
+        Text = "Secondary text color",
+    }
+    return translations[name]
+end
+
+local function scanTrainerSwitches(widget, now)
+    widget.trainerSwitches = logic.findTrainerSwitches(model.getCustomFunction, FUNC_TRAINER)
+    widget.lastScan = now
+end
+
+local function poll(widget)
+    local now = getTime()
+    if widget.lastScan == nil or now - widget.lastScan >= RESCAN_INTERVAL then
+        scanTrainerSwitches(widget, now)
+    end
+
+    local status = getTrainerStatus()
+    if status ~= widget.rawStatus then
+        widget.rawStatus = status
+        widget.statusChangedAt = now
+    end
+
+    local showReconnected =
+        status == 3 and widget.statusChangedAt ~= nil and now - widget.statusChangedAt < RECONNECTED_DURATION
+    local controlRequested = logic.isControlRequested(widget.trainerSwitches, getSwitchValue)
+
+    widget.stateKey, widget.state =
+        logic.classify(status, controlRequested, showReconnected)
+    widget.configured = #widget.trainerSwitches > 0
+end
+
+local function stateColor(widget)
+    local colors = {
+        connected = widget.options.Connected,
+        active = widget.options.Active,
+        warning = widget.options.Warning,
+        neutral = widget.options.Neutral,
+    }
+    return colors[widget.state.color] or widget.options.Neutral
+end
+
+local function drawStatusDot(x, y, radius, color)
+    lcd.drawFilledCircle(x, y, radius, color)
+    lcd.drawCircle(x, y, radius, COLOR_THEME_PRIMARY1)
+end
+
+local function textWidth(text, flags)
+    local width = lcd.sizeText(text, flags)
+    return width
+end
+
+local function chooseText(full, short, maxWidth, fonts)
+    for _, font in ipairs(fonts) do
+        if textWidth(full, font) <= maxWidth then
+            return full, font
+        end
+    end
+
+    for _, font in ipairs(fonts) do
+        if textWidth(short, font) <= maxWidth then
+            return short, font
+        end
+    end
+
+    return short, fonts[#fonts]
+end
+
+local function drawCenteredPair(zone, y, leftText, leftFlags, rightText, rightFlags, gap, color)
+    local leftWidth = textWidth(leftText, leftFlags)
+    local rightWidth = textWidth(rightText, rightFlags)
+    local startX = zone.x + (zone.w - leftWidth - gap - rightWidth) // 2
+
+    lcd.drawText(startX, y, leftText, LEFT + VCENTER + leftFlags + color)
+    lcd.drawText(startX + leftWidth + gap, y, rightText,
+                 LEFT + VCENTER + rightFlags + color)
+end
+
+local function drawTiny(widget, color)
+    local zone = widget.zone
+    local centerY = zone.y + zone.h // 2
+    local iconFlags = MIDSIZE
+    local labelFlags = SMLSIZE + BOLD
+    local gap = 4
+    local contentWidth = textWidth(CHAR_TRAINER, iconFlags) + gap +
+                         textWidth(widget.state.short, labelFlags)
+
+    if contentWidth > zone.w - 6 then
+        lcd.drawText(zone.x + zone.w // 2, centerY, CHAR_TRAINER,
+                     CENTER + VCENTER + iconFlags + color)
+        drawStatusDot(zone.x + zone.w - 6, zone.y + 6, 3, color)
+        return
+    end
+
+    drawCenteredPair(zone, centerY, CHAR_TRAINER, iconFlags,
+                     widget.state.short, labelFlags, gap, color)
+end
+
+local function drawCompact(widget, color)
+    local zone = widget.zone
+    local centerY = zone.y + zone.h // 2
+    local iconFlags = MIDSIZE
+    local gap = 6
+    local labelWidth = zone.w - textWidth(CHAR_TRAINER, iconFlags) - gap - 8
+    local label, labelFlags = chooseText(widget.state.label, widget.state.short,
+                                         labelWidth, { MIDSIZE + BOLD, SMLSIZE + BOLD })
+
+    drawCenteredPair(zone, centerY, CHAR_TRAINER, iconFlags,
+                     label, labelFlags, gap, color)
+end
+
+local function drawMedium(widget, color)
+    local zone = widget.zone
+    local centerY = zone.y + zone.h // 2
+    local iconFlags = MIDSIZE
+    local gap = 7
+    local labelWidth = zone.w - textWidth(CHAR_TRAINER, iconFlags) - gap - 12
+    local label, labelFlags = chooseText(widget.state.label, widget.state.short,
+                                         labelWidth, { MIDSIZE + BOLD, SMLSIZE + BOLD })
+    local detail, detailFlags = chooseText(widget.state.detail, widget.state.short,
+                                           zone.w - 12, { SMLSIZE, TINSIZE })
+
+    drawCenteredPair(zone, centerY - 12, CHAR_TRAINER, iconFlags,
+                     label, labelFlags, gap, color)
+    lcd.drawText(zone.x + zone.w // 2, centerY + 14, detail,
+                 CENTER + VCENTER + detailFlags + widget.options.Text)
+
+    if not widget.configured then
+        lcd.drawText(zone.x + zone.w // 2, zone.y + zone.h - 3,
+                     "No Trainer function", CENTER + VBOTTOM + TINSIZE + widget.options.Neutral)
+    end
+end
+
+local function drawLarge(widget, color)
+    local zone = widget.zone
+    local centerX = zone.x + zone.w // 2
+    local stateY = zone.y + math.max(44, zone.h * 2 // 5)
+    local rowY = zone.y + zone.h - 34
+    local headerIconFlags = MIDSIZE
+    local headerLabelFlags = MIDSIZE + BOLD
+    local stateFontChoices = zone.h >= 190 and
+                                 { DBLSIZE + BOLD, MIDSIZE + BOLD, SMLSIZE + BOLD } or
+                                 { MIDSIZE + BOLD, SMLSIZE + BOLD }
+    local stateLabel, stateFlags = chooseText(widget.state.label, widget.state.short,
+                                               zone.w - 16, stateFontChoices)
+    local detail, detailFlags = chooseText(widget.state.detail, widget.state.short,
+                                           zone.w - 16, { SMLSIZE, TINSIZE })
+
+    drawCenteredPair(zone, zone.y + 20, CHAR_TRAINER, headerIconFlags,
+                     "TRAINER", headerLabelFlags, 8, widget.options.Text)
+    lcd.drawText(centerX, stateY, stateLabel,
+                 CENTER + VCENTER + stateFlags + color)
+    lcd.drawText(centerX, stateY + 32, detail,
+                 CENTER + VCENTER + detailFlags + widget.options.Text)
+
+    local control = widget.configured and widget.state.control or "Not configured"
+    local rowTextWidth = (zone.w - 48) // 2
+    local linkText, linkFlags = chooseText("Link: " .. widget.state.link,
+                                           widget.state.link, rowTextWidth,
+                                           { SMLSIZE, TINSIZE })
+    local controlText, controlFlags = chooseText("Control: " .. control,
+                                                 control, rowTextWidth,
+                                                 { SMLSIZE, TINSIZE })
+
+    drawStatusDot(zone.x + 16, rowY, 5, color)
+    lcd.drawText(zone.x + 28, rowY, linkText,
+                 LEFT + VCENTER + linkFlags + widget.options.Text)
+    lcd.drawText(zone.x + zone.w - 8, rowY, controlText,
+                 RIGHT + VCENTER + controlFlags + widget.options.Text)
+end
+
+local function draw(widget)
+    local color = stateColor(widget)
+    local layout = logic.layoutForZone(widget.zone)
+
+    if layout == "tiny" then
+        drawTiny(widget, color)
+    elseif layout == "compact" then
+        drawCompact(widget, color)
+    elseif layout == "medium" then
+        drawMedium(widget, color)
+    else
+        drawLarge(widget, color)
+    end
+end
+
+local function create(zone, widgetOptions)
+    local widget = {
+        zone = zone,
+        options = widgetOptions,
+        trainerSwitches = {},
+    }
+    poll(widget)
+    return widget
+end
+
+local function update(widget, widgetOptions)
+    widget.options = widgetOptions
+    widget.lastScan = nil
+    poll(widget)
+end
+
+local function background(widget)
+    poll(widget)
+end
+
+local function refresh(widget)
+    poll(widget)
+    draw(widget)
+end
+
+return {
+    name = appName,
+    options = options,
+    create = create,
+    update = update,
+    refresh = refresh,
+    background = background,
+    translate = translate,
+}

--- a/tests/trainer_widget_test.lua
+++ b/tests/trainer_widget_test.lua
@@ -1,0 +1,332 @@
+local failures = 0
+local assertions = 0
+
+local function fail(message)
+    failures = failures + 1
+    io.stderr:write("FAIL: " .. message .. "\n")
+end
+
+local function expectEqual(actual, expected, message)
+    assertions = assertions + 1
+    if actual ~= expected then
+        fail(string.format("%s (expected %s, got %s)", message, tostring(expected), tostring(actual)))
+    end
+end
+
+local function expectTrue(actual, message)
+    expectEqual(actual, true, message)
+end
+
+local logic = assert(loadfile("sdcard/color/WIDGETS/Trainer/logic.lua"))()
+
+local cases = {
+    { 0, false, false, "waiting" },
+    { 0, true, false, "waiting_requested" },
+    { 1, false, false, "connected" },
+    { 1, true, false, "active" },
+    { 2, false, false, "lost" },
+    { 2, true, false, "lost_requested" },
+    { 3, false, true, "reconnected" },
+    { 3, false, false, "connected" },
+    { 3, true, true, "active" },
+    { 99, false, false, "unknown" },
+}
+
+for index, case in ipairs(cases) do
+    local key = logic.classify(case[1], case[2], case[3])
+    expectEqual(key, case[4], "state matrix case " .. index)
+end
+
+local customFunctions = {
+    [0] = { func = 1, switch = 10, active = 1 },
+    [1] = { func = 2, switch = 20, active = 1 },
+    [2] = { func = 1, switch = -11, active = true },
+    [3] = { func = 1, switch = 10, active = 1 },
+    [4] = { func = 1, switch = 12, active = 0 },
+}
+
+local function getCustomFunction(index)
+    if index > 5 then return nil end
+    return customFunctions[index] or { func = 0, switch = 0, active = 0 }
+end
+
+local switches = logic.findTrainerSwitches(getCustomFunction, 1)
+expectEqual(#switches, 2, "trainer switch discovery deduplicates switches")
+expectEqual(switches[1], 10, "first trainer switch")
+expectEqual(switches[2], -11, "inverted trainer switch")
+expectTrue(logic.isControlRequested(switches, function(switch) return switch == -11 end),
+           "any configured trainer switch can request control")
+expectEqual(logic.isControlRequested(switches, function() return false end), false,
+            "inactive trainer switches leave instructor in control")
+
+expectEqual(logic.layoutForZone({ w = 70, h = 39 }), "tiny", "top-bar layout")
+expectEqual(logic.layoutForZone({ w = 160, h = 60 }), "compact", "compact layout")
+expectEqual(logic.layoutForZone({ w = 225, h = 98 }), "medium", "medium layout")
+expectEqual(logic.layoutForZone({ w = 460, h = 252 }), "large", "large layout")
+
+local calls = {}
+local now = 0
+local trainerStatus = 0
+local switchValues = {}
+local trainerFunctionConfigured = true
+
+COLOR = 1
+COLOR_THEME_PRIMARY1 = 0x10000
+COLOR_THEME_PRIMARY2 = 0x20000
+COLOR_THEME_ACTIVE = 0x30000
+COLOR_THEME_WARNING = 0x40000
+COLOR_THEME_DISABLED = 0x50000
+FUNC_TRAINER = 1
+LEFT = 0x01
+RIGHT = 0x02
+CENTER = 0x04
+VCENTER = 0x08
+VBOTTOM = 0x10
+MIDSIZE = 0x20
+DBLSIZE = 0x40
+SMLSIZE = 0x80
+TINSIZE = 0x100
+BOLD = 0x200
+CHAR_TRAINER = "T"
+
+local function textSize(text, flags)
+    local width
+    local height
+
+    if flags & DBLSIZE ~= 0 then
+        width = #text * 30
+        height = 40
+    elseif flags & MIDSIZE ~= 0 then
+        width = text == CHAR_TRAINER and 22 or #text * 10
+        height = 18
+    elseif flags & SMLSIZE ~= 0 then
+        width = #text * 6
+        height = 12
+    else
+        width = #text * 5
+        height = 8
+    end
+
+    return width, height
+end
+
+local function record(name, ...)
+    calls[#calls + 1] = { name = name, args = { ... } }
+end
+
+lcd = {
+    drawText = function(...) record("drawText", ...) end,
+    drawFilledCircle = function(...) record("drawFilledCircle", ...) end,
+    drawCircle = function(...) record("drawCircle", ...) end,
+    sizeText = textSize,
+}
+
+model = {
+    getCustomFunction = function(index)
+        if trainerFunctionConfigured and index == 0 then
+            return { func = FUNC_TRAINER, switch = 7, active = 1 }
+        elseif index < 64 then
+            return { func = 0, switch = 0, active = 0 }
+        end
+        return nil
+    end,
+}
+
+function getTime() return now end
+function getTrainerStatus() return trainerStatus end
+function getSwitchValue(switch) return switchValues[switch] == true end
+function loadScript(path)
+    return assert(loadfile("sdcard/color" .. path))
+end
+
+local descriptor = assert(loadfile("sdcard/color/WIDGETS/Trainer/main.lua"))()
+local widgetOptions = {
+    Connected = COLOR_THEME_PRIMARY2,
+    Active = COLOR_THEME_ACTIVE,
+    Warning = COLOR_THEME_WARNING,
+    Neutral = COLOR_THEME_DISABLED,
+    Text = COLOR_THEME_PRIMARY1,
+}
+
+local function renderedText(expected)
+    for _, call in ipairs(calls) do
+        if call.name == "drawText" and call.args[3] == expected then
+            return true
+        end
+    end
+    return false
+end
+
+local function textBounds(call)
+    local x = call.args[1]
+    local y = call.args[2]
+    local width, height = textSize(call.args[3], call.args[4])
+    local flags = call.args[4]
+
+    if flags & CENTER ~= 0 then
+        x = x - width // 2
+    elseif flags & RIGHT ~= 0 then
+        x = x - width
+    end
+
+    if flags & VCENTER ~= 0 then
+        y = y - height // 2
+    elseif flags & VBOTTOM ~= 0 then
+        y = y - height
+    end
+
+    return x, y, x + width, y + height
+end
+
+local function callsStayInside(zone)
+    for _, call in ipairs(calls) do
+        local x = call.args[1]
+        local y = call.args[2]
+        if call.name == "drawText" then
+            local left, top, right, bottom = textBounds(call)
+            if left < zone.x or right > zone.x + zone.w or
+               top < zone.y or bottom > zone.y + zone.h then
+                return false
+            end
+        elseif call.name == "drawFilledCircle" or call.name == "drawCircle" then
+            local radius = call.args[3]
+            if x - radius < zone.x or x + radius > zone.x + zone.w or
+               y - radius < zone.y or y + radius > zone.y + zone.h then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+local function textCallsDoNotOverlap()
+    local textCalls = {}
+    for _, call in ipairs(calls) do
+        if call.name == "drawText" then
+            textCalls[#textCalls + 1] = call
+        end
+    end
+
+    for first = 1, #textCalls do
+        local leftA, topA, rightA, bottomA = textBounds(textCalls[first])
+        for second = first + 1, #textCalls do
+            local leftB, topB, rightB, bottomB = textBounds(textCalls[second])
+            if leftA < rightB and rightA > leftB and topA < bottomB and bottomA > topB then
+                return false
+            end
+        end
+    end
+
+    return true
+end
+
+local function renderedTextUses(expected, flag)
+    for _, call in ipairs(calls) do
+        if call.name == "drawText" and call.args[3] == expected then
+            return call.args[4] & flag ~= 0
+        end
+    end
+    return false
+end
+
+local function render(zone, status, requested)
+    calls = {}
+    trainerStatus = status
+    switchValues[7] = requested
+    local widget = descriptor.create(zone, widgetOptions)
+    descriptor.refresh(widget)
+    return widget
+end
+
+expectEqual(descriptor.name, "Trainer", "widget name")
+
+local topBarZone = { x = 0, y = 0, w = 70, h = 39 }
+render(topBarZone, 0, false)
+expectTrue(renderedText("WAIT"), "tiny layout renders waiting state")
+expectTrue(callsStayInside(topBarZone), "top-bar drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "top-bar icon and text do not overlap")
+
+local narrowTopBarZone = { x = 0, y = 0, w = 45, h = 39 }
+render(narrowTopBarZone, 1, true)
+expectTrue(renderedText(CHAR_TRAINER), "narrow top bar retains the trainer icon")
+expectEqual(renderedText("LIVE"), false, "narrow top bar drops text that cannot fit")
+expectTrue(callsStayInside(narrowTopBarZone), "narrow top-bar drawing stays inside its zone")
+
+local compactZone = { x = 3, y = 4, w = 160, h = 60 }
+render(compactZone, 1, false)
+expectTrue(renderedText("CONNECTED"), "compact layout renders the full connected state when it fits")
+expectTrue(callsStayInside(compactZone), "compact drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "compact icon and text do not overlap")
+
+render(compactZone, 1, true)
+expectTrue(renderedText("STUDENT CONTROL"), "compact layout retains the full active state at a smaller size")
+expectTrue(renderedTextUses("STUDENT CONTROL", SMLSIZE),
+           "compact active state selects a font that fits")
+expectTrue(callsStayInside(compactZone), "compact active drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "compact active icon and text do not overlap")
+
+local mediumZone = { x = 10, y = 20, w = 225, h = 98 }
+render(mediumZone, 1, true)
+expectTrue(renderedText("STUDENT CONTROL"), "medium layout renders active student control")
+expectTrue(renderedText("Trainer input is active"), "medium layout renders active detail")
+expectTrue(callsStayInside(mediumZone), "medium drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "medium icon, state, and detail do not overlap")
+
+local narrowMediumZone = { x = 10, y = 20, w = 150, h = 90 }
+render(narrowMediumZone, 1, true)
+expectTrue(renderedText("STUDENT CONTROL"), "narrow medium layout preserves the full active state")
+expectTrue(callsStayInside(narrowMediumZone), "narrow medium drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "narrow medium content does not overlap")
+
+local largeZone = { x = 5, y = 7, w = 460, h = 252 }
+render(largeZone, 2, true)
+expectTrue(renderedText("LINK LOST"), "large layout renders link loss")
+expectTrue(renderedText("Control: Requested"), "large layout renders requested control")
+expectTrue(callsStayInside(largeZone), "large drawing stays inside its zone")
+
+render(largeZone, 1, true)
+expectTrue(renderedText("STUDENT CONTROL"), "large layout renders the full active state")
+expectTrue(renderedTextUses("STUDENT CONTROL", MIDSIZE),
+           "large active state reduces its font when double size would overflow")
+expectEqual(renderedTextUses("STUDENT CONTROL", DBLSIZE), false,
+            "large active state does not use an overflowing double-size font")
+expectTrue(callsStayInside(largeZone), "large active drawing stays inside its zone")
+
+local minimumLargeZone = { x = 5, y = 7, w = 240, h = 130 }
+render(minimumLargeZone, 1, true)
+expectTrue(renderedText("STUDENT CONTROL"), "minimum large layout preserves the full active state")
+expectTrue(renderedTextUses("STUDENT CONTROL", MIDSIZE),
+           "minimum large layout avoids a vertically oversized font")
+expectTrue(callsStayInside(minimumLargeZone), "minimum large drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "minimum large content does not overlap")
+
+trainerFunctionConfigured = false
+render(largeZone, 1, false)
+expectTrue(renderedText("Control: Not configured"), "missing Trainer function is reported")
+
+render(minimumLargeZone, 1, false)
+expectTrue(renderedText("Not configured"),
+           "minimum large layout shortens the unconfigured control label")
+expectTrue(callsStayInside(minimumLargeZone),
+           "minimum large unconfigured drawing stays inside its zone")
+expectTrue(textCallsDoNotOverlap(), "minimum large unconfigured content does not overlap")
+trainerFunctionConfigured = true
+
+trainerStatus = 3
+switchValues[7] = false
+now = 1000
+local reconnected = descriptor.create({ x = 0, y = 0, w = 225, h = 98 }, widgetOptions)
+calls = {}
+descriptor.refresh(reconnected)
+expectTrue(renderedText("RECONNECTED"), "reconnected state is announced")
+now = now + 201
+calls = {}
+descriptor.refresh(reconnected)
+expectTrue(renderedText("CONNECTED"), "reconnected state settles to connected")
+
+if failures > 0 then
+    io.stderr:write(string.format("%d of %d assertions failed\n", failures, assertions))
+    os.exit(1)
+end
+
+print(string.format("PASS: %d trainer widget assertions", assertions))


### PR DESCRIPTION
## Summary

- Add a generic color-screen `Trainer` widget to every supported color SD-card package.
- Distinguish never connected, connected/reconnected, previously connected but lost, and unsafe control-request-without-link states.
- Discover enabled model special functions using `FUNC_TRAINER` automatically.
- Adapt top-bar, compact, medium, and large layouts using measured text widths.
- Add pure Lua coverage for state classification, special-function discovery, layout selection, text bounds, font fallback, and overlap prevention.

## Why

EdgeTX/edgetx#627 requested a visible trainer connection and control indicator. EdgeTX/edgetx#2483 added `getTrainerStatus()` specifically to enable such a widget, but the graphical widget was never added.

Automatic special-function discovery avoids requiring users to configure the trainer control switch twice and supports multiple or inverted Trainer switches.

The widget is read-only, uses built-in drawing primitives and the trainer glyph, and adds no bitmap assets or firmware-size cost.

## Layout behavior

- The trainer glyph and label are measured and centered as one group instead of being anchored to opposite edges.
- Narrow top-bar zones fall back to an icon plus status dot when the short label cannot fit.
- Compact and medium zones select the largest full label that fits, then fall back to smaller text or the short state.
- The trainer glyph is rendered separately at a supported size so it remains visible.
- Large states such as `STUDENT CONTROL` automatically reduce their font rather than being clipped.
- Tests validate complete text rectangles, not only their anchor coordinates.

## Validation

- `lua tests/trainer_widget_test.lua`: 57 assertions passed.
- Lua syntax checks passed for the widget and logic module.
- `luacheck`: 0 warnings and 0 errors with EdgeTX runtime globals declared.
- `uv run pytest`: 21/21 passed.
- `uv run ruff check .` and `uv run ruff format --check .`: passed.
- `uv run generate.py` completed in a clean Linux checkout.
- `WIDGETS/Trainer/main.lua` and `logic.lua` verified in all five generated color archives.

No physical radio is required for these checks.

Closes EdgeTX/edgetx#627