### PR TITLE
feat(widget): add last-known GPS recovery QR

### DIFF
--- a/sdcard/color/WIDGETS/RecoveryQR/README.md
+++ b/sdcard/color/WIDGETS/RecoveryQR/README.md
@@ -1,0 +1,60 @@
+# Recovery QR
+
+Recovery QR is an EdgeTX color-screen widget that turns the model's latest
+valid GPS telemetry position into a QR code. Scanning the code opens that
+position in Google Maps.
+
+The widget keeps the last position visible when telemetry is lost and restores
+it after the radio restarts. Positions are stored separately for each model.
+
+## Requirements
+
+- EdgeTX 3.0 or later with the Lua LVGL API
+- A color-screen radio
+- A configured GPS telemetry sensor
+
+## Setup
+
+1. Add **Recovery QR** to a widget zone.
+2. Open the widget settings.
+3. Select the model's GPS telemetry source.
+4. Double-tap the widget to display the large, scannable QR code.
+
+## States
+
+- **LIVE GPS**: valid coordinates are currently arriving.
+- **LAST KNOWN**: telemetry is unavailable and the last received position is
+  displayed.
+- **WAITING FOR GPS**: no valid position has been received or restored.
+
+The first valid position is saved immediately. While telemetry remains live,
+the widget checkpoints at most once every 15 seconds. The newest position is
+also saved immediately when telemetry is lost. This limits SD-card writes while
+preserving the most useful recovery coordinate.
+
+Saved positions use model-specific files in `/WIDGETS/RecoveryQR/`. A
+full-screen confirmation button can clear a stored position when telemetry is
+not live.
+
+## Notes
+
+- The QR code contains a URL in the form
+  `https://maps.google.com/?q=latitude,longitude`.
+- The widget itself does not make a network request or transmit coordinates.
+- A receiver that publishes `0,0` before obtaining a fix is treated as not
+  having a valid position.
+- The last telemetry coordinate is a recovery aid, not a guarantee of the
+  aircraft's final resting position.
+
+This widget implements the color-radio use case described in
+[EdgeTX issue #4614](https://github.com/EdgeTX/edgetx/issues/4614).
+
+## Development check
+
+The repository includes a host-side test covering GPS validation, state
+transitions, persistence recovery, model isolation, LVGL layout construction,
+and all supported color-screen dimensions:
+
+```sh
+lua5.3 tests/recovery_qr_widget_test.lua
+```

--- a/sdcard/color/WIDGETS/RecoveryQR/logic.lua
+++ b/sdcard/color/WIDGETS/RecoveryQR/logic.lua
@@ -1,0 +1,186 @@
+--
+-- Copyright (C) EdgeTX
+--
+-- License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+--
+
+local M = {}
+
+local COORDINATE_PRECISION = 6
+local GOOGLE_MAPS_PREFIX = "https://maps.google.com/?q="
+
+local function isFinite(value)
+    return type(value) == "number"
+        and value == value
+        and value ~= math.huge
+        and value ~= -math.huge
+end
+
+local function formatCoordinate(value)
+    local text = string.format("%." .. COORDINATE_PRECISION .. "f", value)
+    if text == "-0.000000" then
+        return "0.000000"
+    end
+    return text
+end
+
+function M.normalizeGps(value)
+    if type(value) ~= "table" then
+        return nil
+    end
+
+    local lat = tonumber(value.lat)
+    local lon = tonumber(value.lon)
+    if not isFinite(lat) or not isFinite(lon) then
+        return nil
+    end
+    if lat < -90 or lat > 90 or lon < -180 or lon > 180 then
+        return nil
+    end
+
+    -- Telemetry receivers commonly publish 0,0 before acquiring a fix.
+    if lat == 0 and lon == 0 then
+        return nil
+    end
+
+    return {
+        lat = lat,
+        lon = lon,
+        delay = tonumber(value.delay),
+    }
+end
+
+function M.coordinateText(position)
+    if position == nil then
+        return "--.------, --.------"
+    end
+    return formatCoordinate(position.lat) .. ", " .. formatCoordinate(position.lon)
+end
+
+function M.mapsUrl(position)
+    if position == nil then
+        return nil
+    end
+    return GOOGLE_MAPS_PREFIX
+        .. formatCoordinate(position.lat)
+        .. ","
+        .. formatCoordinate(position.lon)
+end
+
+function M.captureStamp(dateTime)
+    if type(dateTime) ~= "table" then
+        return "Unknown time"
+    end
+
+    local year = tonumber(dateTime.year)
+    local month = tonumber(dateTime.mon)
+    local day = tonumber(dateTime.day)
+    local hour = tonumber(dateTime.hour)
+    local minute = tonumber(dateTime.min)
+    local second = tonumber(dateTime.sec)
+    if not year or not month or not day or not hour or not minute or not second then
+        return "Unknown time"
+    end
+
+    return string.format(
+        "%04d-%02d-%02d %02d:%02d:%02d",
+        year, month, day, hour, minute, second
+    )
+end
+
+function M.newRecord(position, captured)
+    if position == nil then
+        return nil
+    end
+    return {
+        lat = position.lat,
+        lon = position.lon,
+        captured = captured or "Unknown time",
+    }
+end
+
+function M.serializeRecord(record)
+    if record == nil then
+        return nil
+    end
+
+    return table.concat({
+        "RecoveryQR,1",
+        "lat=" .. formatCoordinate(record.lat),
+        "lon=" .. formatCoordinate(record.lon),
+        "captured=" .. tostring(record.captured or "Unknown time"),
+        "",
+    }, "\n")
+end
+
+function M.parseRecord(data)
+    if type(data) ~= "string" or not string.find(data, "^RecoveryQR,1\n") then
+        return nil
+    end
+
+    local lat = tonumber(string.match(data, "\nlat=([^\n]+)"))
+    local lon = tonumber(string.match(data, "\nlon=([^\n]+)"))
+    local captured = string.match(data, "\ncaptured=([^\n]+)")
+    local position = M.normalizeGps({ lat = lat, lon = lon })
+    if position == nil or captured == nil or captured == "" then
+        return nil
+    end
+
+    return M.newRecord(position, captured)
+end
+
+function M.sanitizeModelKey(filename)
+    local key = tostring(filename or "")
+    key = string.gsub(key, "%.[^%.]+$", "")
+    key = string.gsub(key, "[^%w_-]", "_")
+    key = string.sub(key, 1, 32)
+    if key == "" then
+        return "default"
+    end
+    return key
+end
+
+function M.state(live, record)
+    if live and record ~= nil then
+        return "live"
+    elseif record ~= nil then
+        return "stored"
+    end
+    return "waiting"
+end
+
+function M.layoutForZone(width, height, fullscreen)
+    width = tonumber(width) or 0
+    height = tonumber(height) or 0
+
+    if fullscreen then
+        return "fullscreen"
+    elseif width < 90 or height < 48 then
+        return "tiny"
+    elseif width < 260 or height < 150 then
+        return "compact"
+    end
+    return "qr"
+end
+
+function M.shouldPersist(lastSavedSignature, signature, lastSavedAt, now,
+                         wasLive, isLive, interval)
+    if signature == nil or signature == lastSavedSignature then
+        return false
+    end
+    if lastSavedSignature == nil then
+        return true
+    end
+    if wasLive and not isLive then
+        return true
+    end
+    if not isLive then
+        return false
+    end
+    if lastSavedAt == nil or now == nil or now < lastSavedAt then
+        return true
+    end
+    return now - lastSavedAt >= (interval or 0)
+end
+
+return M

--- a/sdcard/color/WIDGETS/RecoveryQR/main.lua
+++ b/sdcard/color/WIDGETS/RecoveryQR/main.lua
@@ -1,0 +1,502 @@
+--
+-- Copyright (C) EdgeTX
+--
+-- License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+--
+
+local appName = "Recovery QR"
+local scriptDirectory = "/WIDGETS/RecoveryQR"
+local logic = assert(loadScript(scriptDirectory .. "/logic.lua", "btd"))()
+local storage = assert(loadScript(scriptDirectory .. "/storage.lua", "btd"))()
+
+local SAVE_INTERVAL = 1500 -- 15 seconds, in 10 ms ticks
+local SAVE_RETRY_INTERVAL = 100 -- 1 second
+local QR_REFRESH_INTERVAL = 100 -- 1 second
+
+local options = {
+    { "GPS", SOURCE, { "GPS", "GPos" } },
+    { "Live", COLOR, COLOR_THEME_ACTIVE },
+    { "Stored", COLOR, COLOR_THEME_WARNING },
+    { "Text", COLOR, COLOR_THEME_PRIMARY1 },
+    { "Muted", COLOR, COLOR_THEME_DISABLED },
+}
+
+local function translate(name)
+    local translations = {
+        GPS = "GPS telemetry source",
+        Live = "Live position color",
+        Stored = "Stored position color",
+        Text = "Text color",
+        Muted = "Secondary text color",
+    }
+    return translations[name]
+end
+
+local function modelIdentity()
+    local info = model.getInfo() or {}
+    local filename = info.filename or info.name or "default"
+    return logic.sanitizeModelKey(filename), info.name or filename
+end
+
+local function statusLabel(widget)
+    if widget.state == "live" then
+        return "LIVE GPS"
+    elseif widget.state == "stored" then
+        return "LAST KNOWN"
+    end
+    return "WAITING FOR GPS"
+end
+
+local function statusDetail(widget)
+    if widget.state == "live" then
+        return "Position updates while telemetry is available"
+    elseif widget.state == "stored" then
+        return "Telemetry lost - showing the saved position"
+    end
+    return "Select a GPS telemetry source"
+end
+
+local function statusColor(widget)
+    if widget.state == "live" then
+        return widget.options.Live
+    elseif widget.state == "stored" then
+        return widget.options.Stored
+    end
+    return widget.options.Muted
+end
+
+local function coordinateText(widget)
+    return logic.coordinateText(widget.record)
+end
+
+local function capturedText(widget)
+    if widget.record == nil then
+        return "No position recorded"
+    end
+    return "Captured " .. widget.record.captured
+end
+
+local function qrData(widget)
+    return logic.mapsUrl(widget.record) or "https://www.edgetx.org"
+end
+
+local function loadStoredRecord(widget)
+    widget.record = storage.load(widget.paths, logic.parseRecord)
+    if widget.record ~= nil then
+        widget.lastSavedSignature = logic.serializeRecord(widget.record)
+        widget.lastSavedAt = getTime()
+    end
+end
+
+local function persistIfNeeded(widget, wasLive, now)
+    if widget.record == nil or not widget.recordDirty then
+        return
+    end
+
+    local telemetryLost = wasLive and not widget.live
+    if widget.lastSaveAttemptAt ~= nil
+        and now >= widget.lastSaveAttemptAt
+        and now - widget.lastSaveAttemptAt < SAVE_RETRY_INTERVAL
+        and not telemetryLost
+    then
+        return
+    end
+
+    if widget.lastSavedSignature ~= nil and not telemetryLost then
+        if not widget.live then
+            return
+        end
+        if widget.lastSavedAt ~= nil
+            and now >= widget.lastSavedAt
+            and now - widget.lastSavedAt < SAVE_INTERVAL
+        then
+            return
+        end
+    end
+
+    local signature = logic.serializeRecord(widget.record)
+    local shouldPersist = logic.shouldPersist(
+        widget.lastSavedSignature,
+        signature,
+        widget.lastSavedAt,
+        now,
+        wasLive,
+        widget.live,
+        SAVE_INTERVAL
+    )
+    if not shouldPersist then
+        if signature == widget.lastSavedSignature then
+            widget.recordDirty = false
+        end
+        return
+    end
+
+    widget.lastSaveAttemptAt = now
+    if storage.save(widget.paths, signature) then
+        widget.lastSavedSignature = signature
+        widget.lastSavedAt = now
+        widget.recordDirty = false
+    end
+end
+
+local function poll(widget)
+    local now = getTime()
+    local wasLive = widget.live
+    local previousPayload = logic.mapsUrl(widget.record)
+    local position = logic.normalizeGps(getValue(widget.options.GPS))
+
+    widget.live = position ~= nil
+    if position ~= nil then
+        local payload = logic.mapsUrl(position)
+        local refreshCaptureTime = widget.lastCaptureAt == nil
+            or now < widget.lastCaptureAt
+            or now - widget.lastCaptureAt >= 100
+        if payload ~= previousPayload or refreshCaptureTime then
+            widget.record = logic.newRecord(
+                position,
+                logic.captureStamp(getDateTime())
+            )
+            widget.lastCaptureAt = now
+            widget.recordDirty = true
+        end
+    end
+
+    widget.state = logic.state(widget.live, widget.record)
+    persistIfNeeded(widget, wasLive, now)
+
+    local currentPayload = logic.mapsUrl(widget.record)
+    local qrRefreshDue = widget.lastQrBuildAt == nil
+        or now < widget.lastQrBuildAt
+        or now - widget.lastQrBuildAt >= QR_REFRESH_INTERVAL
+    if currentPayload ~= widget.renderedPayload
+        and (
+            widget.renderedPayload == nil
+            or qrRefreshDue
+            or (wasLive and not widget.live)
+        )
+    then
+        widget.layoutDirty = true
+    end
+end
+
+local function clearStoredPosition(widget)
+    if widget.live then
+        return
+    end
+
+    storage.clear(widget.paths)
+    widget.record = nil
+    widget.state = logic.state(false, nil)
+    widget.lastSavedSignature = nil
+    widget.lastSavedAt = nil
+    widget.lastSaveAttemptAt = nil
+    widget.recordDirty = false
+    widget.layoutDirty = true
+end
+
+local function confirmClear(widget)
+    lvgl.confirm({
+        title = "Clear saved position",
+        message = "Remove the last known GPS position for this model?",
+        confirm = function()
+            clearStoredPosition(widget)
+        end,
+    })
+end
+
+local function statusLayout(widget, width, height, compact)
+    local statusFont = compact and MIDSIZE or DBLSIZE
+    local coordinateFont = compact and SMLSIZE or MIDSIZE
+    local centerY = height // 2
+
+    return {
+        {
+            type = "label",
+            x = 6,
+            y = compact and 3 or centerY - 35,
+            w = width - 12,
+            text = function() return statusLabel(widget) end,
+            color = function() return statusColor(widget) end,
+            font = statusFont,
+            align = CENTER,
+        },
+        {
+            type = "label",
+            x = 6,
+            y = compact and centerY - 2 or centerY + 2,
+            w = width - 12,
+            text = function() return coordinateText(widget) end,
+            color = widget.options.Text,
+            font = coordinateFont,
+            align = CENTER,
+        },
+        {
+            type = "label",
+            x = 6,
+            y = height - 23,
+            w = width - 12,
+            text = function() return capturedText(widget) end,
+            color = widget.options.Muted,
+            font = TINSIZE,
+            align = CENTER,
+        },
+    }
+end
+
+local function tinyLayout(widget, width, height)
+    return {
+        {
+            type = "label",
+            x = 2,
+            y = 1,
+            w = width - 4,
+            h = height - 2,
+            text = function()
+                if widget.state == "live" then
+                    return "GPS LIVE"
+                elseif widget.state == "stored" then
+                    return "GPS SAVED"
+                end
+                return "NO GPS"
+            end,
+            color = function() return statusColor(widget) end,
+            font = SMLSIZE,
+            align = CENTER + VCENTER,
+        },
+    }
+end
+
+local function qrLayout(widget, width, height, fullscreen)
+    local margin = fullscreen and 10 or 6
+    local headerHeight = fullscreen and 38 or 0
+    local footerHeight = fullscreen and 42 or 0
+    local portrait = fullscreen and height > width
+    local availableHeight = height - headerHeight - footerHeight - margin * 2
+    local outerSize
+    if portrait then
+        outerSize = math.min(
+            width - margin * 2,
+            availableHeight * 65 // 100
+        )
+    else
+        outerSize = math.min(availableHeight, width * 52 // 100 - margin)
+    end
+    local quietZone = math.max(8, outerSize // 10)
+    local qrSize = outerSize - quietZone * 2
+    local outerX = portrait and (width - outerSize) // 2 or margin
+    local outerY = headerHeight + margin
+    local qrX = outerX + quietZone
+    local qrY = outerY + quietZone
+    local textX = portrait and margin or outerX + outerSize + margin * 2
+    local textWidth = portrait and width - margin * 2
+        or width - textX - margin
+    local statusY = portrait and outerY + outerSize + margin
+        or qrY + math.max(2, qrSize // 8)
+    local statusFont = fullscreen and (
+        width < 400 or portrait
+    ) and MIDSIZE or (fullscreen and DBLSIZE or MIDSIZE)
+    local coordinateFont = fullscreen and (
+        width < 400 or portrait
+    ) and SMLSIZE or (fullscreen and MIDSIZE or SMLSIZE)
+    local coordinateOffset = portrait and 28 or (fullscreen and 45 or 32)
+    local capturedOffset = portrait and 52 or (fullscreen and 80 or 57)
+    local detailOffset = portrait and 75 or (fullscreen and 112 or 80)
+    local modelOffset = portrait and 98 or (fullscreen and 155 or 105)
+    local textAlign = portrait and CENTER or nil
+
+    local layout = {
+        {
+            type = "rectangle",
+            x = outerX,
+            y = outerY,
+            w = outerSize,
+            h = outerSize,
+            color = WHITE,
+            filled = true,
+            visible = function() return widget.record ~= nil end,
+        },
+        {
+            type = "qrcode",
+            x = qrX,
+            y = qrY,
+            w = qrSize,
+            data = qrData(widget),
+            color = BLACK,
+            bgColor = WHITE,
+            visible = function() return widget.record ~= nil end,
+        },
+        {
+            type = "label",
+            x = textX,
+            y = statusY,
+            w = textWidth,
+            text = function() return statusLabel(widget) end,
+            color = function() return statusColor(widget) end,
+            font = statusFont,
+            align = textAlign,
+        },
+        {
+            type = "label",
+            x = textX,
+            y = statusY + coordinateOffset,
+            w = textWidth,
+            text = function() return coordinateText(widget) end,
+            color = widget.options.Text,
+            font = coordinateFont,
+            align = textAlign,
+        },
+        {
+            type = "label",
+            x = textX,
+            y = statusY + capturedOffset,
+            w = textWidth,
+            text = function() return capturedText(widget) end,
+            color = widget.options.Muted,
+            font = SMLSIZE,
+            align = textAlign,
+        },
+        {
+            type = "label",
+            x = textX,
+            y = statusY + detailOffset,
+            w = textWidth,
+            text = function() return statusDetail(widget) end,
+            color = widget.options.Muted,
+            font = SMLSIZE,
+            align = textAlign,
+        },
+        {
+            type = "label",
+            x = textX,
+            y = statusY + modelOffset,
+            w = textWidth,
+            text = function() return widget.modelName end,
+            color = widget.options.Text,
+            font = SMLSIZE,
+            visible = function()
+                return not portrait and (not fullscreen or height >= 300)
+            end,
+            align = textAlign,
+        },
+    }
+
+    if fullscreen then
+        table.insert(layout, {
+            type = "label",
+            x = 10,
+            y = 5,
+            w = width - 20,
+            text = width < 400 and "RECOVERY QR" or "RECOVERY QR - Scan to navigate",
+            color = widget.options.Text,
+            font = MIDSIZE,
+            align = CENTER,
+        })
+        table.insert(layout, {
+            type = "button",
+            x = width - 155,
+            y = height - 38,
+            w = 145,
+            h = 32,
+            text = "Clear position",
+            visible = function()
+                return not widget.live and widget.record ~= nil
+            end,
+            press = function()
+                confirmClear(widget)
+            end,
+        })
+    end
+
+    return layout
+end
+
+local function buildLayout(widget)
+    if lvgl == nil or widget.zone == nil then
+        return
+    end
+
+    local width = widget.fullscreen and LCD_W or (widget.zone.w or 0)
+    local height = widget.fullscreen and LCD_H or (widget.zone.h or 0)
+    if width <= 0 or height <= 0 then
+        return
+    end
+
+    local layoutName = logic.layoutForZone(width, height, widget.fullscreen)
+    local layout
+    if layoutName == "tiny" then
+        layout = tinyLayout(widget, width, height)
+    elseif layoutName == "compact" or widget.record == nil then
+        layout = statusLayout(widget, width, height, true)
+    elseif layoutName == "fullscreen" then
+        layout = qrLayout(widget, width, height, true)
+    else
+        layout = qrLayout(widget, width, height, false)
+    end
+
+    lvgl.clear()
+    lvgl.build(layout)
+    widget.renderedPayload = logic.mapsUrl(widget.record)
+    widget.lastQrBuildAt = getTime()
+    widget.layoutDirty = false
+end
+
+local function create(zone, widgetOptions)
+    local modelKey, modelName = modelIdentity()
+    local widget = {
+        zone = zone,
+        options = widgetOptions,
+        modelName = modelName,
+        paths = storage.paths(scriptDirectory, modelKey),
+        live = false,
+        fullscreen = false,
+        layoutDirty = true,
+        recordDirty = false,
+    }
+
+    loadStoredRecord(widget)
+    poll(widget)
+    return widget
+end
+
+local function update(widget, widgetOptions)
+    widget.options = widgetOptions
+    widget.layoutDirty = true
+    poll(widget)
+    buildLayout(widget)
+end
+
+local function background(widget)
+    poll(widget)
+end
+
+local function refresh(widget, event, touchState)
+    local fullscreen = event ~= nil
+    if fullscreen and (
+        event == EVT_VIRTUAL_EXIT
+        or (touchState ~= nil and touchState.tapCount == 2)
+    ) then
+        lvgl.exitFullScreen()
+        return
+    end
+
+    if fullscreen ~= widget.fullscreen then
+        widget.fullscreen = fullscreen
+        widget.layoutDirty = true
+    end
+
+    poll(widget)
+    if widget.layoutDirty then
+        buildLayout(widget)
+    end
+end
+
+return {
+    name = appName,
+    options = options,
+    create = create,
+    update = update,
+    refresh = refresh,
+    background = background,
+    translate = translate,
+    useLvgl = true,
+}

--- a/sdcard/color/WIDGETS/RecoveryQR/main.lua
+++ b/sdcard/color/WIDGETS/RecoveryQR/main.lua
@@ -84,7 +84,7 @@ local function loadStoredRecord(widget)
     widget.record = storage.load(widget.paths, logic.parseRecord)
     if widget.record ~= nil then
         widget.lastSavedSignature = logic.serializeRecord(widget.record)
-        widget.lastSavedAt = getTime()
+        widget.lastSavedAt = nil
     end
 end
 

--- a/sdcard/color/WIDGETS/RecoveryQR/storage.lua
+++ b/sdcard/color/WIDGETS/RecoveryQR/storage.lua
@@ -1,0 +1,97 @@
+--
+-- Copyright (C) EdgeTX
+--
+-- License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+--
+
+local M = {}
+
+local function defaultRead(path)
+    local handle = io.open(path, "r")
+    if handle == nil then
+        return nil
+    end
+    local data = io.read(handle, 512)
+    io.close(handle)
+    return data
+end
+
+local function defaultWrite(path, data)
+    local handle = io.open(path, "w")
+    if handle == nil then
+        return false
+    end
+    io.write(handle, data)
+    io.close(handle)
+    return true
+end
+
+local function defaultDelete(path)
+    return del(path)
+end
+
+local function defaultRename(fromPath, toPath)
+    return rename(fromPath, toPath)
+end
+
+local function operations(custom)
+    custom = custom or {}
+    return {
+        read = custom.read or defaultRead,
+        write = custom.write or defaultWrite,
+        delete = custom.delete or defaultDelete,
+        rename = custom.rename or defaultRename,
+    }
+end
+
+function M.paths(directory, modelKey)
+    local base = directory .. "/last_" .. modelKey .. ".txt"
+    return {
+        current = base,
+        temporary = base .. ".tmp",
+        backup = base .. ".bak",
+    }
+end
+
+function M.load(paths, parser, customOperations)
+    local ops = operations(customOperations)
+    local record = parser(ops.read(paths.current))
+    if record ~= nil then
+        return record
+    end
+    return parser(ops.read(paths.backup))
+end
+
+function M.save(paths, data, customOperations)
+    if type(data) ~= "string" then
+        return false
+    end
+
+    local ops = operations(customOperations)
+    ops.delete(paths.temporary)
+    if not ops.write(paths.temporary, data) then
+        return false
+    end
+
+    ops.delete(paths.backup)
+    local movedCurrent = ops.rename(paths.current, paths.backup) == 0
+    if ops.rename(paths.temporary, paths.current) ~= 0 then
+        if movedCurrent then
+            ops.rename(paths.backup, paths.current)
+        end
+        ops.delete(paths.temporary)
+        return false
+    end
+
+    ops.delete(paths.backup)
+    return true
+end
+
+function M.clear(paths, customOperations)
+    local ops = operations(customOperations)
+    ops.delete(paths.temporary)
+    ops.delete(paths.backup)
+    return ops.delete(paths.current) == 0
+end
+
+return M

--- a/sdcard/color/WIDGETS/RecoveryQR/storage.lua
+++ b/sdcard/color/WIDGETS/RecoveryQR/storage.lua
@@ -5,6 +5,7 @@
 --
 
 local M = {}
+local FILE_NOT_FOUND = 4
 
 local function defaultRead(path)
     local handle = io.open(path, "r")
@@ -91,7 +92,8 @@ function M.clear(paths, customOperations)
     local ops = operations(customOperations)
     ops.delete(paths.temporary)
     ops.delete(paths.backup)
-    return ops.delete(paths.current) == 0
+    local result = ops.delete(paths.current)
+    return result == 0 or result == FILE_NOT_FOUND
 end
 
 return M

--- a/tests/recovery_qr_widget_test.lua
+++ b/tests/recovery_qr_widget_test.lua
@@ -151,6 +151,8 @@ expect(storage.clear(paths, memoryOperations(false)))
 expectEqual(files[paths.current], nil)
 expectEqual(files[paths.temporary], nil)
 expectEqual(files[paths.backup], nil)
+expect(storage.clear(paths, memoryOperations(false)),
+    "clearing an already absent record should succeed")
 
 -- Exercise the widget lifecycle with a small EdgeTX API mock. This catches
 -- integration errors in main.lua without requiring a radio.
@@ -355,6 +357,18 @@ widgetModule.update(restarted, widgetOptions)
 expectEqual(restarted.state, "stored",
     "a new widget instance should restore the saved position")
 expectEqual(logic.mapsUrl(restarted.record), qrObject.data)
+
+gpsValue = { lat = 40.2, lon = -74.3, delay = 0 }
+currentSecond = 21
+now = 1802
+widgetModule.refresh(restarted, nil, nil)
+expect(string.find(
+    widgetFiles["/WIDGETS/RecoveryQR/last_Rescue_Plane.txt"],
+    "lat=40.200000",
+    1,
+    true
+) ~= nil, "the first new fix after loading should persist immediately")
+gpsValue = 0
 
 currentModelFilename = "Another Model.yml"
 currentModelName = "Another Model"

--- a/tests/recovery_qr_widget_test.lua
+++ b/tests/recovery_qr_widget_test.lua
@@ -1,0 +1,413 @@
+local logic = assert(loadfile("sdcard/color/WIDGETS/RecoveryQR/logic.lua"))()
+local storage = assert(loadfile("sdcard/color/WIDGETS/RecoveryQR/storage.lua"))()
+
+local testsRun = 0
+
+local function expect(condition, message)
+    testsRun = testsRun + 1
+    if not condition then
+        error(message or "expectation failed", 2)
+    end
+end
+
+local function expectEqual(actual, expected, message)
+    expect(actual == expected, (message or "values differ")
+        .. ": expected " .. tostring(expected)
+        .. ", got " .. tostring(actual))
+end
+
+local function expectNear(actual, expected, epsilon, message)
+    expect(math.abs(actual - expected) <= epsilon, message or "values are not near")
+end
+
+local valid = logic.normalizeGps({ lat = 40.1234567, lon = -74.7654321, delay = 2 })
+expect(valid ~= nil, "valid GPS data should be accepted")
+expectNear(valid.lat, 40.1234567, 0.00000001)
+expectNear(valid.lon, -74.7654321, 0.00000001)
+expectEqual(valid.delay, 2)
+
+expectEqual(logic.normalizeGps(nil), nil)
+expectEqual(logic.normalizeGps(0), nil)
+expectEqual(logic.normalizeGps({ lat = "bad", lon = 1 }), nil)
+expectEqual(logic.normalizeGps({ lat = 91, lon = 1 }), nil)
+expectEqual(logic.normalizeGps({ lat = 1, lon = -181 }), nil)
+expectEqual(logic.normalizeGps({ lat = 0, lon = 0 }), nil)
+expect(logic.normalizeGps({ lat = 0, lon = 1 }) ~= nil)
+expectEqual(logic.normalizeGps({ lat = 0 / 0, lon = 1 }), nil)
+expectEqual(logic.normalizeGps({ lat = math.huge, lon = 1 }), nil)
+
+expectEqual(
+    logic.coordinateText(valid),
+    "40.123457, -74.765432",
+    "coordinates should use six decimal places"
+)
+expectEqual(
+    logic.mapsUrl(valid),
+    "https://maps.google.com/?q=40.123457,-74.765432",
+    "map URL should contain normalized coordinates"
+)
+expectEqual(
+    logic.coordinateText({ lat = -0.0000001, lon = 0.0000001 }),
+    "0.000000, 0.000000",
+    "negative zero should not be displayed"
+)
+
+local stamp = logic.captureStamp({
+    year = 2026, mon = 7, day = 29, hour = 14, min = 5, sec = 9,
+})
+expectEqual(stamp, "2026-07-29 14:05:09")
+expectEqual(logic.captureStamp(nil), "Unknown time")
+
+local record = logic.newRecord(valid, stamp)
+local serialized = logic.serializeRecord(record)
+local parsed = logic.parseRecord(serialized)
+expect(parsed ~= nil, "serialized record should parse")
+expectNear(parsed.lat, 40.123457, 0.0000001)
+expectNear(parsed.lon, -74.765432, 0.0000001)
+expectEqual(parsed.captured, stamp)
+expectEqual(logic.parseRecord(""), nil)
+expectEqual(logic.parseRecord("RecoveryQR,2\nlat=1\nlon=2\ncaptured=now\n"), nil)
+expectEqual(logic.parseRecord("RecoveryQR,1\nlat=bad\nlon=2\ncaptured=now\n"), nil)
+
+expectEqual(logic.sanitizeModelKey("My Plane.yml"), "My_Plane")
+expectEqual(logic.sanitizeModelKey("../../bad:model.yml"), "______bad_model")
+expectEqual(logic.sanitizeModelKey(nil), "default")
+expectEqual(#logic.sanitizeModelKey(string.rep("a", 50) .. ".yml"), 32)
+
+expectEqual(logic.state(true, record), "live")
+expectEqual(logic.state(false, record), "stored")
+expectEqual(logic.state(false, nil), "waiting")
+expectEqual(logic.layoutForZone(60, 40, false), "tiny")
+expectEqual(logic.layoutForZone(180, 100, false), "compact")
+expectEqual(logic.layoutForZone(220, 125, false), "compact")
+expectEqual(logic.layoutForZone(300, 180, false), "qr")
+expectEqual(logic.layoutForZone(60, 40, true), "fullscreen")
+
+expect(logic.shouldPersist(nil, "a", nil, 100, false, true, 1500))
+expect(not logic.shouldPersist("a", "a", 100, 2000, true, true, 1500))
+expect(not logic.shouldPersist("a", "b", 100, 1000, true, true, 1500))
+expect(logic.shouldPersist("a", "b", 100, 1600, true, true, 1500))
+expect(logic.shouldPersist("a", "b", 100, 101, true, false, 1500))
+expect(not logic.shouldPersist("a", "b", 100, 2000, false, false, 1500))
+expect(logic.shouldPersist("a", "b", 2000, 10, true, true, 1500))
+
+local files = {}
+local function memoryOperations(failTemporaryRename)
+    return {
+        read = function(path)
+            return files[path]
+        end,
+        write = function(path, data)
+            files[path] = data
+            return true
+        end,
+        delete = function(path)
+            local existed = files[path] ~= nil
+            files[path] = nil
+            return existed and 0 or 4
+        end,
+        rename = function(fromPath, toPath)
+            if failTemporaryRename and string.find(fromPath, "%.tmp$") then
+                return 1
+            end
+            if files[fromPath] == nil or files[toPath] ~= nil then
+                return 1
+            end
+            files[toPath] = files[fromPath]
+            files[fromPath] = nil
+            return 0
+        end,
+    }
+end
+
+local paths = storage.paths("/WIDGETS/RecoveryQR", "My_Plane")
+expectEqual(paths.current, "/WIDGETS/RecoveryQR/last_My_Plane.txt")
+expect(storage.save(paths, serialized, memoryOperations(false)))
+expectEqual(files[paths.current], serialized)
+expectEqual(files[paths.temporary], nil)
+expectEqual(files[paths.backup], nil)
+
+local loaded = storage.load(paths, logic.parseRecord, memoryOperations(false))
+expect(loaded ~= nil, "saved record should load")
+expectEqual(loaded.captured, stamp)
+
+local previous = serialized
+local replacement = logic.serializeRecord(logic.newRecord(
+    { lat = 41.1, lon = -73.2 },
+    "2026-07-29 14:06:00"
+))
+expect(not storage.save(paths, replacement, memoryOperations(true)))
+expectEqual(files[paths.current], previous, "failed replacement should restore current file")
+expectEqual(files[paths.temporary], nil)
+
+files[paths.current] = "corrupt"
+files[paths.backup] = previous
+loaded = storage.load(paths, logic.parseRecord, memoryOperations(false))
+expect(loaded ~= nil, "valid backup should recover a corrupt current file")
+expectEqual(loaded.captured, stamp)
+
+files[paths.current] = previous
+expect(storage.clear(paths, memoryOperations(false)))
+expectEqual(files[paths.current], nil)
+expectEqual(files[paths.temporary], nil)
+expectEqual(files[paths.backup], nil)
+
+-- Exercise the widget lifecycle with a small EdgeTX API mock. This catches
+-- integration errors in main.lua without requiring a radio.
+SOURCE = 1
+COLOR = 2
+COLOR_THEME_ACTIVE = 10
+COLOR_THEME_WARNING = 11
+COLOR_THEME_PRIMARY1 = 12
+COLOR_THEME_DISABLED = 13
+MIDSIZE = 0x0100
+DBLSIZE = 0x0200
+SMLSIZE = 0x0400
+TINSIZE = 0x0800
+CENTER = 0x1000
+VCENTER = 0x2000
+WHITE = 0xFFFF
+BLACK = 0
+LCD_W = 480
+LCD_H = 272
+EVT_VIRTUAL_EXIT = 99
+
+local now = 100
+local gpsValue = 0
+local currentSecond = 5
+local builtLayout
+local exitedFullscreen = false
+local pendingConfirmation
+local widgetFiles = {}
+local widgetEnvironment
+local currentModelFilename = "Rescue Plane.yml"
+local currentModelName = "Rescue Plane"
+
+model = {
+    getInfo = function()
+        return { filename = currentModelFilename, name = currentModelName }
+    end,
+}
+
+function getTime()
+    return now
+end
+
+function getValue(source)
+    expectEqual(source, 42, "widget should read its configured GPS source")
+    return gpsValue
+end
+
+function getDateTime()
+    return {
+        year = 2026,
+        mon = 7,
+        day = 29,
+        hour = 15,
+        min = 4,
+        sec = currentSecond,
+    }
+end
+
+function loadScript(path)
+    local localPath = string.gsub(
+        path,
+        "^/WIDGETS/RecoveryQR/",
+        "sdcard/color/WIDGETS/RecoveryQR/"
+    )
+    return assert(loadfile(localPath, "t", widgetEnvironment))
+end
+
+local mockIo = {
+    open = function(path, mode)
+        if mode == "r" and widgetFiles[path] == nil then
+            return nil
+        end
+        return { path = path, mode = mode }
+    end,
+    read = function(handle)
+        return widgetFiles[handle.path]
+    end,
+    write = function(handle, data)
+        widgetFiles[handle.path] = data
+        return true
+    end,
+    close = function()
+        return true
+    end,
+}
+
+function del(path)
+    local existed = widgetFiles[path] ~= nil
+    widgetFiles[path] = nil
+    return existed and 0 or 4
+end
+
+function rename(fromPath, toPath)
+    if widgetFiles[fromPath] == nil or widgetFiles[toPath] ~= nil then
+        return 1
+    end
+    widgetFiles[toPath] = widgetFiles[fromPath]
+    widgetFiles[fromPath] = nil
+    return 0
+end
+
+lvgl = {
+    clear = function()
+        builtLayout = nil
+    end,
+    build = function(layout)
+        builtLayout = layout
+    end,
+    confirm = function(specification)
+        pendingConfirmation = specification
+    end,
+    exitFullScreen = function()
+        exitedFullscreen = true
+    end,
+}
+
+widgetEnvironment = setmetatable({
+    io = mockIo,
+}, { __index = _G })
+
+local function findLayoutObject(objectType)
+    if builtLayout == nil then
+        return nil
+    end
+    for _, object in ipairs(builtLayout) do
+        if object.type == objectType then
+            return object
+        end
+    end
+    return nil
+end
+
+local widgetModule = assert(loadfile(
+    "sdcard/color/WIDGETS/RecoveryQR/main.lua",
+    "t",
+    widgetEnvironment
+))()
+expectEqual(widgetModule.name, "Recovery QR")
+expect(widgetModule.useLvgl, "widget should opt into LVGL")
+
+local widgetOptions = {
+    GPS = 42,
+    Live = COLOR_THEME_ACTIVE,
+    Stored = COLOR_THEME_WARNING,
+    Text = COLOR_THEME_PRIMARY1,
+    Muted = COLOR_THEME_DISABLED,
+}
+local widget = widgetModule.create({ x = 0, y = 0, w = 300, h = 180 }, widgetOptions)
+widgetModule.update(widget, widgetOptions)
+expectEqual(widget.state, "waiting")
+expectEqual(findLayoutObject("qrcode"), nil, "waiting layout should not build a QR code")
+
+gpsValue = { lat = 40.1, lon = -74.2, delay = 0 }
+now = 200
+widgetModule.refresh(widget, nil, nil)
+expectEqual(widget.state, "live")
+local qrObject = findLayoutObject("qrcode")
+expect(qrObject ~= nil, "live layout should contain a QR code")
+expectEqual(qrObject.data, "https://maps.google.com/?q=40.100000,-74.200000")
+local quietZone = findLayoutObject("rectangle")
+expect(quietZone ~= nil, "QR layout should include a white quiet zone")
+expect(qrObject.x - quietZone.x >= quietZone.w // 10,
+    "quiet zone should be wide enough for reliable scanning")
+expect(widgetFiles["/WIDGETS/RecoveryQR/last_Rescue_Plane.txt"] ~= nil,
+    "first valid position should be persisted")
+
+gpsValue = { lat = 40.10005, lon = -74.20005, delay = 0 }
+now = 250
+widgetModule.refresh(widget, nil, nil)
+expectEqual(findLayoutObject("qrcode").data, qrObject.data,
+    "rapid GPS changes should not rebuild the QR more than once per second")
+now = 300
+widgetModule.refresh(widget, nil, nil)
+qrObject = findLayoutObject("qrcode")
+expectEqual(qrObject.data, "https://maps.google.com/?q=40.100050,-74.200050",
+    "latest position should reach the QR when the refresh interval expires")
+
+currentSecond = 20
+now = 1800
+widgetModule.refresh(widget, nil, nil)
+expectEqual(widget.record.captured, "2026-07-29 15:04:20",
+    "stationary GPS data should still refresh the capture time")
+expect(string.find(
+    widgetFiles["/WIDGETS/RecoveryQR/last_Rescue_Plane.txt"],
+    "captured=2026-07-29 15:04:20",
+    1,
+    true
+) ~= nil, "live checkpoint should persist the refreshed capture time")
+
+gpsValue = 0
+now = 1801
+widgetModule.refresh(widget, nil, nil)
+expectEqual(widget.state, "stored")
+expectEqual(logic.mapsUrl(widget.record), qrObject.data,
+    "telemetry loss should retain the last position")
+
+local restarted = widgetModule.create(
+    { x = 0, y = 0, w = 300, h = 180 },
+    widgetOptions
+)
+widgetModule.update(restarted, widgetOptions)
+expectEqual(restarted.state, "stored",
+    "a new widget instance should restore the saved position")
+expectEqual(logic.mapsUrl(restarted.record), qrObject.data)
+
+currentModelFilename = "Another Model.yml"
+currentModelName = "Another Model"
+local otherModel = widgetModule.create(
+    { x = 0, y = 0, w = 300, h = 180 },
+    widgetOptions
+)
+widgetModule.update(otherModel, widgetOptions)
+expectEqual(otherModel.state, "waiting",
+    "saved positions should remain isolated by model")
+currentModelFilename = "Rescue Plane.yml"
+currentModelName = "Rescue Plane"
+
+widgetModule.refresh(widget, 0, nil)
+expectEqual(widget.fullscreen, true)
+expect(findLayoutObject("qrcode") ~= nil, "fullscreen layout should contain a QR code")
+
+for _, size in ipairs({
+    { 320, 240 },
+    { 320, 480 },
+    { 480, 272 },
+    { 480, 320 },
+    { 800, 480 },
+}) do
+    LCD_W = size[1]
+    LCD_H = size[2]
+    widget.fullscreen = false
+    widgetModule.refresh(widget, 0, nil)
+    qrObject = findLayoutObject("qrcode")
+    quietZone = findLayoutObject("rectangle")
+    expect(qrObject ~= nil and qrObject.w > 0,
+        "fullscreen QR should have a positive size")
+    expect(quietZone.x >= 0 and quietZone.y >= 0,
+        "quiet zone should start inside the display")
+    expect(quietZone.x + quietZone.w <= LCD_W,
+        "quiet zone should fit the display width")
+    expect(quietZone.y + quietZone.h <= LCD_H,
+        "quiet zone should fit the display height")
+    if LCD_W == 320 and LCD_H == 480 then
+        expect(qrObject.w >= 180,
+            "portrait fullscreen should use the available vertical space")
+    end
+end
+
+local clearButton = findLayoutObject("button")
+expect(clearButton ~= nil, "fullscreen stored layout should contain the clear button")
+clearButton.press()
+expect(pendingConfirmation ~= nil, "clear action should require confirmation")
+pendingConfirmation.confirm()
+expectEqual(widget.state, "waiting")
+expectEqual(widgetFiles["/WIDGETS/RecoveryQR/last_Rescue_Plane.txt"], nil)
+
+widgetModule.refresh(widget, 0, { tapCount = 2 })
+expect(exitedFullscreen, "double tap should exit fullscreen mode")
+
+print(string.format("Recovery QR tests passed: %d", testsRun))


### PR DESCRIPTION
## Summary

- add a generic color-screen **Recovery QR** widget
- turn the latest valid model GPS position into a native LVGL QR code for Google Maps
- keep the last known position available after telemetry loss and radio restart
- isolate saved positions by model and provide a confirmed full-screen clear action
- add responsive layouts for every supported color-screen dimension

## Why

This implements the color-radio recovery workflow requested in EdgeTX/edgetx#4614. The earlier Lua implementation could not generate QR matrices within the color-widget instruction budget; current EdgeTX exposes native LVGL QR generation, so this widget delegates that work to firmware.

The existing Model Locator remains useful while RSSI is available. Recovery QR complements it by preserving the last GPS position after the telemetry link is gone.

## Persistence behavior

- save the first valid fix immediately
- checkpoint live GPS at most once every 15 seconds
- save the newest dirty position immediately when telemetry is lost
- rate-limit QR rebuilds and failed storage retries
- use temporary and backup files so an interrupted replacement can recover the previous record

## Validation

- `lua5.3 tests/recovery_qr_widget_test.lua` — 124 assertions
- Lua syntax validation with `luac5.3 -p`
- `luacheck` — 0 warnings / 0 errors
- official `generate.sh` package generation
- verified identical widget content in c320x240, c320x480, c480x272, c480x320, and c800x480 packages
- verified the widget is excluded from black-and-white packages

The host-side lifecycle test covers GPS validation, URL formatting, live/stored/waiting transitions, stationary fixes, checkpoint throttling, telemetry loss, restart restoration, model isolation, corrupt-file recovery, full-screen controls, QR quiet-zone geometry, and all five color display sizes.

Requires EdgeTX 3.0 or later with the Lua LVGL QR API.

Fixes EdgeTX/edgetx#4614
