### PR TITLE
feat(color): add Gauge Dial Pro and Gauge Bar Pro beta

### DIFF
--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/alerts.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/alerts.lua
@@ -1,0 +1,104 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - threshold alerts                                           #
+---- #                                                                       #
+---- # A gauge that only changes colour is useless when you are looking at   #
+---- # the model. Alerts fire on a state TRANSITION into warning/critical,   #
+---- # never continuously, and are guarded by:                               #
+---- #                                                                       #
+---- #   * a startup delay - a model powering up reports nonsense for a      #
+---- #     second or two; without this every power-on screams CRITICAL       #
+---- #     (the ePowerbar lesson),                                           #
+---- #   * an optional switch, so alerts only arm when the model is armed,   #
+---- #   * a re-arm interval, so a value hovering on a threshold cannot      #
+---- #     machine-gun (state hysteresis in ranges.lua does the rest),       #
+---- #   * data validity - no alerts while the link is down.                 #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+M.OFF, M.CRITICAL, M.ALL = 1, 2, 3
+
+local REPEAT_TICKS = 500   -- 5 s between repeats of the same state
+
+-- A SWITCH option is a swsrc_t (may be negative), not a MIXSRC id: it must be
+-- read with getSwitchValue(), never getValue() (AUDIT.md P0-1). On any
+-- failure to read it, stay armed - a misread switch must not silence alerts.
+local function switchActive(id)
+  if not id or id == 0 then return true end
+  if type(getSwitchValue) ~= "function" then return true end
+  local ok, value = pcall(getSwitchValue, id)
+  if not ok then return true end
+  return value == true
+end
+
+local function play(widget, state)
+  local cfg = widget.config
+  if type(playHaptic) == "function" and cfg.vibrate and state == "critical" then
+    playHaptic(60, 0)
+  end
+  if type(playTone) ~= "function" then return end
+  if state == "critical" then
+    playTone(880, 180, 0)
+    playTone(660, 180, 20)
+  else
+    playTone(660, 120, 0)
+  end
+end
+
+function M.reset(widget)
+  widget.alert = widget.alert or {}
+  widget.alert.state = nil
+  widget.alert.at = 0
+  widget.alert.armedAt = nil
+end
+
+-- Called once per refresh, after telemetry.
+function M.update(widget)
+  local cfg = widget.config
+  local a = widget.alert
+  if not a then
+    M.reset(widget)
+    a = widget.alert
+  end
+  local level = cfg.alerts or M.OFF
+  if level == M.OFF then
+    a.state = nil
+    return
+  end
+
+  local data = widget.data
+  if data.availability ~= "valid" or data.state == nil then
+    a.state = nil
+    -- Re-arm the STARTUP DELAY too, not just the transition: a brownout is
+    -- precisely the "model powering up reports nonsense" case the delay
+    -- exists for (Tanda 6 F-7). Leaving armedAt in the past made the first
+    -- frame after reconnect alert immediately.
+    a.armedAt = nil
+    return
+  end
+
+  local now = getTime()
+  if a.armedAt == nil then
+    a.armedAt = now + (tonumber(cfg.delay) or 0) * 100  -- seconds -> 10 ms
+  end
+  if now < a.armedAt then return end
+  if not switchActive(cfg.alertSw) then return end
+
+  local state = data.state
+  local wanted = (state == "critical")
+    or (level == M.ALL and state == "warning")
+  if not wanted then
+    a.state = state
+    return
+  end
+  if state ~= a.state or (now - a.at) >= REPEAT_TICKS then
+    a.state = state
+    a.at = now
+    play(widget, state)
+  end
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/app.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/app.lua
@@ -1,0 +1,493 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - lifecycle                                                  #
+---- #                                                                       #
+---- # Loaded by main.lua on first use (the official Value2 pattern), so a   #
+---- # radio that never places this widget pays only for main.lua at boot.   #
+---- #                                                                       #
+---- # create()  - state tables + module loading                             #
+---- # update()  - options -> config -> ranges -> layout; rebuilds the LVGL  #
+---- #             tree only when the structural signature changed           #
+---- # refresh() - read telemetry, run alerts, update properties             #
+---- #                                                                       #
+---- # background() is deliberately absent: the firmware only calls it while #
+---- # the widget is OFF screen, so all data maintenance lives in refresh(). #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local input = ...
+-- Frontends pass an explicit product specification. Accepting the historical
+-- bare DEFS array keeps local tools and old compiled mains diagnosable during
+-- the transition, while every shipping frontend uses the structured form.
+local SPEC
+if type(input) == "table" and type(input.defs) == "table" then
+  SPEC = input
+else
+  SPEC = { name = "GaugePro", family = nil, coreApi = 1, defs = input }
+end
+local DEFS = assert(SPEC.defs, "GaugePro: missing frontend option definitions")
+local CORE_API = 1
+if type(SPEC.name) ~= "string" or SPEC.name == "" then
+  error("GaugeCore: frontend name must be a non-empty string")
+end
+if SPEC.family ~= nil and SPEC.family ~= "dial" and SPEC.family ~= "bar" then
+  error(SPEC.name .. ": invalid GaugeCore family " .. tostring(SPEC.family))
+end
+if SPEC.coreApi ~= CORE_API then
+  error((SPEC.name or "GaugePro") .. ": incompatible GaugeCore API (expected "
+    .. tostring(SPEC.coreApi) .. ", found " .. tostring(CORE_API) .. ")")
+end
+
+local M = {}
+M.coreApi = CORE_API
+
+-- Shared product semantics are always present. Bar-only presentation and
+-- motion are loaded only for GaugeBarPro (or for the legacy auto-dispatcher).
+-- This matters on EdgeTX: each loaded chunk has a real RAM cost even when no
+-- function from it is ever called.
+local COMMON_MODULES = {
+  "theme", "geometry", "format", "options", "ranges", "presets",
+  "smoothing", "telemetry", "layout_common", "ui_core", "alerts",
+}
+local DIAL_MODULES = { "dial_layout", "dial_renderer" }
+local BAR_MODULES = {
+  "motion", "bar_layout", "bar_style", "bar_faces", "bar",
+}
+
+local function moduleNames()
+  local names = {}
+  for i = 1, #COMMON_MODULES do names[#names + 1] = COMMON_MODULES[i] end
+  if SPEC.family == "dial" or SPEC.family == nil then
+    for i = 1, #DIAL_MODULES do names[#names + 1] = DIAL_MODULES[i] end
+  end
+  if SPEC.family == "bar" or SPEC.family == nil then
+    for i = 1, #BAR_MODULES do names[#names + 1] = BAR_MODULES[i] end
+  end
+  return names
+end
+
+local SCALE_AUTO = 1
+local BATTERY_OFF = 1
+
+-- Presentation aliases are deliberately exact and tiny. They must never feed
+-- back into telemetry lookup, preset matching or persistence: `source.name`
+-- remains the firmware identifier and only `nameText` consumes this mapping.
+-- Do not normalize arbitrary third-party names; their spelling belongs to the
+-- sensor author. Label overrides are resolved by configure() before this
+-- helper, so user-authored text always wins.
+local SOURCE_NAME_ALIASES = {
+  ["tx-voltage"] = "TX VOLTAGE",
+  ["TX_VOLTAGE"] = "TX VOLTAGE",
+}
+
+local function presentSourceName(name)
+  if type(name) ~= "string" then return "" end
+  return SOURCE_NAME_ALIASES[name] or name
+end
+M.presentSourceName = presentSourceName
+
+-- The module table is SHARED by every widget instance: the modules are pure
+-- (all per-widget state lives in the `widget` table), the setup() calls are
+-- idempotent, and theme's metric caches are exactly what should be shared
+-- across instances. main.lua also memoizes app.lua itself, so one screen
+-- with four gauges loads each required chunk once rather than once per
+-- instance (AUDIT.md P2-3).
+-- Keyed by path so two differently-located copies of the widget stay
+-- independent.
+local MODS_BY_PATH = {}
+
+local function loadModules(path)
+  local mods = MODS_BY_PATH[path]
+  if mods then return mods end
+  mods = {}
+  MODS_BY_PATH[path] = mods
+  local names = moduleNames()
+  for i = 1, #names do
+    local name = names[i]
+    local chunk, err = loadScript(path .. name .. ".lua", "bt")
+    if not chunk then
+      error((SPEC.name or "GaugePro") .. ": cannot load " .. name
+        .. " from " .. path .. " (" .. tostring(err) .. ")")
+    end
+    local ok, mod = pcall(chunk)
+    if not ok or type(mod) ~= "table" then
+      error((SPEC.name or "GaugePro") .. ": bad module " .. name
+        .. " from " .. path .. " (" .. tostring(mod) .. ")")
+    end
+    mods[name] = mod
+  end
+  mods.layout_common.setup(mods.theme, mods.geometry, mods.format)
+  if mods.dial_layout then
+    mods.dial_layout.setup(mods.layout_common, mods.theme, mods.geometry,
+                           mods.format)
+  end
+  if mods.bar_layout then
+    mods.bar_layout.setup(mods.layout_common, mods.theme, mods.geometry,
+                          mods.format)
+  end
+
+  -- Compatibility facade used by the lifecycle. It composes exactly one
+  -- family for the new frontends and both only for GaugePro legacy.
+  mods.layout = {
+    calculate = function(widget, cfg)
+      local w, h = widget.zone.w, widget.zone.h
+      local mode, orientation = mods.layout_common.classify(w, h)
+      local layout = { mode = mode, orientation = orientation, w = w, h = h }
+      local style = mods.layout_common.pickStyle(cfg, w, h, widget.family)
+      if style == "bar" then
+        return assert(mods.bar_layout,
+          "GaugeCore: Bar layout was not loaded").calculate(widget, cfg, layout)
+      end
+      return assert(mods.dial_layout,
+        "GaugeCore: Dial layout was not loaded").calculate(widget, cfg, layout)
+    end,
+    signature = mods.layout_common.signature,
+    applyBarVisual = mods.bar_layout and mods.bar_layout.applyBarVisual,
+  }
+  mods.ui_core.setup(mods.theme, mods.geometry, mods.format)
+  if mods.dial_renderer then
+    mods.dial_renderer.setup(mods.ui_core, mods.theme, mods.geometry,
+                             mods.format)
+  end
+  -- Public compatibility alias for existing diagnostics and tests. It points
+  -- at the genuinely shared UI primitives, never at the dial renderer.
+  mods.renderer = mods.ui_core
+  if mods.dial_renderer then
+    mods.renderer.angleOf = mods.dial_renderer.angleOf
+    mods.renderer.bandSpan = mods.dial_renderer.bandSpan
+  end
+  if mods.motion then mods.motion.setup(mods.theme) end
+  if mods.bar_style then mods.bar_style.setup(mods.theme, mods.presets) end
+  if mods.bar_faces then
+    mods.bar_faces.setup(mods.theme, mods.geometry, mods.renderer)
+  end
+  if mods.bar then
+    mods.bar.setup(mods.theme, mods.geometry, mods.format, mods.renderer,
+                   mods.bar_faces, mods.motion, mods.bar_style)
+  end
+  return mods
+end
+
+function M.create(zone, options, path)
+  path = path or "/SCRIPTS/TOOLS/GaugeCore/"
+  local widget = {
+    zone = zone,
+    options = options,
+    path = path,
+    family = SPEC.family,
+    frontendName = SPEC.name or "GaugePro",
+    defs = DEFS,
+    mods = loadModules(path),
+    -- `gen` counts REAL resolutions of the source (telemetry.resolveSource);
+    -- configure() stamps widget.sourceGen with it so refresh() can spot a
+    -- source that resolved after the last configure.
+    source = { id = -1, resolved = false, name = "", unitName = "", gen = 0 },
+    data = { availability = "unset" },
+    history = {},
+    smooth = {},
+    alert = {},
+    ui = {},
+    frame = { props = {} },
+    unitText = "",
+    nameText = "",
+  }
+  return widget
+end
+
+-- Which renderer draws this layout.
+local function painter(widget)
+  return (widget.layout.style == "bar") and widget.mods.bar
+      or widget.mods.dial_renderer
+end
+M.painter = painter
+
+-- A dense segmented face can require nearly forty retained LVGL objects.
+-- Building that tree in the same callback that parses all 2.12 options and
+-- resolves layout/theme metadata needlessly concentrates the work. Existing
+-- widgets therefore stage a structural settings rebuild: update() resolves
+-- and latches the new structure, the next refresh builds it, and the normal
+-- paint resumes one frame later. Initial creation and telemetry-driven
+-- reconfiguration still build immediately because no prior tree exists (or
+-- because refresh already owns the bounded callback).
+local function rebuild(widget)
+  widget.rebuildPending = false
+  lvgl.clear()
+  widget.ui = {}
+  widget.frame = { props = {}, dirty = {} }
+  painter(widget).build(widget)
+end
+
+-- Ranges, derived text and layout. Called from update(), and from refresh()
+-- through the two one-shot latches there: the frame a battery pack's cell
+-- count becomes known, and the frame a late-arriving sensor finally resolves.
+local function configure(widget, deferRebuild)
+  local m, cfg, src = widget.mods, widget.config, widget.source
+
+  -- Everything below is DERIVED from `src`. Record which resolution of the
+  -- source it was derived from, so refresh() can tell when a late-resolving
+  -- sensor has left it stale (telemetry.resolveSource bumps src.gen).
+  widget.sourceGen = src.gen
+
+  -- scale: Auto uses a known-sensor preset, Manual always uses the user
+  -- values. On firmware without the Scale option (2.11, ten slots) Auto keeps
+  -- the original behaviour: presets apply only while the ranges are untouched.
+  local auto
+  if widget.hasScaleOption then
+    auto = (cfg.scale == SCALE_AUTO)
+  else
+    auto = (cfg.rawMin == 0 and cfg.rawMax == 100 and cfg.rawWarn == 55
+            and cfg.rawCrit == 35)
+  end
+
+  local minimum, maximum = cfg.rawMin, cfg.rawMax
+  local warning, critical = cfg.rawWarn, cfg.rawCrit
+  local highGood = cfg.highGood
+  local precision = cfg.precision
+
+  -- F-12: autoCells is auto-branch state and must default FALSE - the old
+  -- code only wrote it inside the auto branch, so switching Auto -> Manual
+  -- (or -> Battery) left a stale latch lying around (Tanda 6 F-12).
+  widget.autoCells = false
+
+  if cfg.battery ~= BATTERY_OFF then
+    -- state of charge: the scale is always a percentage
+    minimum, maximum, warning, critical, highGood = 0, 100, 30, 15, true
+    precision = 0
+  elseif auto then
+    local preset = m.presets.find(src)
+    widget.autoCells = (preset ~= nil) and preset.battery or false
+    if preset then
+      minimum, maximum = preset.minimum, preset.maximum
+      warning, critical = preset.warning, preset.critical
+      highGood = preset.highIsGood
+      -- a pack voltage scale only means something once the cell count is
+      -- known; until then keep the single-cell preset. And only for a
+      -- reading that IS the pack total: a `cellsTable` source (Cels) showing
+      -- Lowest or Average is still single-cell magnitude no matter how many
+      -- cells were detected - rescaling it to the pack range would clamp it
+      -- permanently near the bottom of the dial (AUDIT.md P1-6).
+      local wantsPackRange = not preset.cellsTable
+        or cfg.cells == m.telemetry.CELLS_TOTAL
+      if preset.battery and src.cells and src.cells > 1 and wantsPackRange then
+        local pack = m.presets.packRange(src.cells, "lipo")
+        minimum, maximum = pack.minimum, pack.maximum
+        warning, critical = pack.warning, pack.critical
+        highGood = pack.highIsGood
+      end
+    end
+  end
+
+  -- When BOTH thresholds are out of the effective range on the same side,
+  -- building the bands from them would turn the whole dial critical with
+  -- zero-width warning/normal bands (e.g. a manual -120..0 dBm scale with
+  -- the 0..100 defaults). Derive them at the presets' proportions instead
+  -- (AUDIT.md G-4).
+  warning, critical = m.ranges.saneThresholds(minimum, maximum, warning,
+                                              critical, highGood)
+  cfg.min, cfg.max, cfg.warn, cfg.crit = minimum, maximum, warning, critical
+  cfg.highGood = highGood
+
+  -- precision: Auto (1) follows the sensor, else the chosen decimal count
+  if cfg.precisionChoice > 1 then
+    precision = cfg.precisionChoice - 2
+  elseif cfg.battery == BATTERY_OFF then
+    precision = src.prec or 0
+    if src.name == "tx-voltage" then precision = 1 end
+  end
+  cfg.precision = precision
+
+  -- displayed strings
+  if cfg.suffix and cfg.suffix ~= "" then
+    widget.unitText = cfg.suffix
+  elseif cfg.battery ~= BATTERY_OFF then
+    widget.unitText = "%"
+  else
+    widget.unitText = src.unitName or ""
+  end
+  widget.nameText = (cfg.label and cfg.label ~= "") and cfg.label
+                    or presentSourceName(src.name)
+
+  widget.ranges = m.ranges.build(cfg.min, cfg.max, cfg.warn, cfg.crit,
+                                 cfg.highGood)
+  widget.deadband = m.ranges.deadband(cfg.min, cfg.max)
+
+  local rangeSig = table.concat({ cfg.min, cfg.max, cfg.warn, cfg.crit,
+                                  cfg.highGood and 1 or 0, cfg.precision }, ":")
+  -- Battery mode and the Cells aggregation mode change which UNIT the
+  -- displayed value is in without necessarily changing cfg.min/max (e.g.
+  -- Lowest -> Total on a Cels source keeps the same pack-range scale), so
+  -- rangeSig alone would miss it and leave stale per-cell-volt history mixed
+  -- with pack-total readings (AUDIT.md P0-7).
+  local historySig = tostring(cfg.battery) .. ":" .. tostring(cfg.cells)
+  if rangeSig ~= widget.rangeSig or historySig ~= widget.historySig then
+    widget.rangeSig = rangeSig
+    widget.historySig = historySig
+    m.telemetry.resetHistory(widget)
+    m.smoothing.reset(widget)
+    if widget.motionState then m.motion.reset(widget) end
+  end
+
+  local L = m.layout.calculate(widget, cfg)
+  -- Resolve bar appearance from immutable stored config only when the active
+  -- layout can consume it. A dial ignores every bar-only option, so it should
+  -- not pay RGB analysis/cache-signature cost during configure either.
+  if L.style == "bar" then
+    widget.barVisual, widget.barPalette = m.bar_style.resolve(widget, cfg)
+    widget.limitNotice = widget.barVisual.notice
+    m.layout.applyBarVisual(L, widget.barVisual, cfg)
+  else
+    widget.barVisual, widget.barPalette = nil, nil
+    widget.limitNotice = nil
+  end
+  widget.layout = L
+  -- rangeSig is included so a range edit (min/max/warn/crit/precision, or the
+  -- battery cell latch) rebuilds everything derived from it at BUILD time:
+  -- section/rail arcs, bar threshold marks, scale end labels (AUDIT.md P0-2).
+  local sig = m.layout.signature(L, cfg) .. ":" .. widget.unitText
+    .. ":" .. widget.rangeSig
+  if L.style == "bar" then
+    sig = sig .. ":" .. widget.barVisual.structuralSig
+  end
+  if sig ~= widget.layoutSig then
+    widget.layoutSig = sig
+    widget.layoutRebuilt = true
+    -- New split frontends stage their initial tree too: parsing/resolution
+    -- and a rich Bar build in one callback measured above the 10k structural
+    -- guardrail. GaugePro legacy keeps its historical immediate first build.
+    local staged = deferRebuild and ((widget.ui and widget.ui.built)
+      or SPEC.family ~= nil)
+    if staged then
+      widget.rebuildPending = true
+    else
+      rebuild(widget)
+    end
+  end
+end
+M.configure = configure
+
+-- configure() PLUS the cheap delta path for text a rebuild did not repaint.
+-- Every caller needs both halves: a signature change rebuilds the tree and
+-- paints the current strings itself, but a config change that leaves the
+-- signature alone - a Name/Suffix edit, or a source whose unit is empty -
+-- only reaches the screen through updateSourceLabels (AUDIT.md P0-6).
+-- Splitting the two across call sites is what let the late-resolution path
+-- draw an unnamed, unitless gauge.
+local function apply(widget, deferRebuild)
+  widget.layoutRebuilt = false
+  configure(widget, deferRebuild)
+  -- setProp() no-ops when the string is unchanged, so this is free on the
+  -- common "nothing moved" call.
+  if not widget.layoutRebuilt then
+    painter(widget).updateSourceLabels(widget)
+  end
+end
+M.apply = apply
+
+function M.update(widget, options)
+  if not widget.mods then return end
+  widget.options = options
+  local m = widget.mods
+
+  widget.hasScaleOption = (options.Scale ~= nil)
+  local cfg = m.options.parse(DEFS, options)
+  -- keep the authored values: configure() writes the *effective* scale into
+  -- cfg.min/max, and the Auto heuristic must keep seeing what the user set
+  cfg.rawMin, cfg.rawMax = cfg.min, cfg.max
+  cfg.rawWarn, cfg.rawCrit = cfg.warn, cfg.crit
+  cfg.precisionChoice = cfg.precision
+  cfg.tau = m.smoothing.tau(cfg.damping)
+  widget.config = cfg
+  widget.accent = (cfg.accent and cfg.accent ~= 0) and cfg.accent or nil
+
+  local prevId = widget.source.id
+  local src = m.telemetry.resolveSource(widget)
+  if src.id ~= prevId then
+    widget.data.lastValue = nil   -- never show a new source's old data
+    widget.data.state = nil
+    src.cells = nil
+    widget.cellsApplied = nil   -- let the NEW source's cell count re-latch
+    m.telemetry.resetHistory(widget)
+    m.smoothing.reset(widget)
+    if widget.motionState then m.motion.reset(widget) end
+    m.alerts.reset(widget)
+  end
+
+  apply(widget, true)
+end
+
+-- A SWITCH option is a swsrc_t, read with getSwitchValue() (AUDIT.md P0-1),
+-- never getValue(). Unlike the alert switch, a misread here must NOT trigger
+-- a reset, so any failure to read leaves resetArmed unchanged (no edge).
+local function checkResetSwitch(widget)
+  local sw = widget.config.resetSw
+  if not sw or sw == 0 then return end
+  if type(getSwitchValue) ~= "function" then return end
+  local ok, value = pcall(getSwitchValue, sw)
+  if not ok then return end
+  local active = (value == true)
+  if active and not widget.resetArmed then
+    local idx = widget.source.sensorIndex
+    if idx and type(model) == "table" and type(model.resetSensor) == "function" then
+      -- For a real telemetry sensor, resetHistory() alone is undone within
+      -- THIS SAME refresh(): telemetry.refresh() calls readHistorySiblings()
+      -- right after, which reads the radio's own <name>-/<name>+ sources
+      -- straight back, unreset (AUDIT.md P1-8). model.resetSensor() is the
+      -- same primitive the official "Reset telemetry" action uses.
+      model.resetSensor(idx)
+    end
+    widget.mods.telemetry.resetHistory(widget)
+  end
+  widget.resetArmed = active
+end
+
+function M.refresh(widget, _event, _touch)
+  if not widget.mods then return end
+  if widget.rebuildPending then
+    rebuild(widget)
+    return
+  end
+  if not widget.ui.built then return end
+  local m = widget.mods
+  checkResetSwitch(widget)
+  m.telemetry.refresh(widget)
+
+  -- Two things can invalidate the derived config from inside a frame. At most
+  -- ONE of them is applied per refresh: apply() costs a full configure (~8k
+  -- VM instructions on a large dial) against a 20000-instruction per-callback
+  -- budget (lua_widget.cpp MAX_INSTRUCTIONS), and doing both in one frame
+  -- would put two rebuilds in a single callback. Whichever does not fire this
+  -- frame fires on the next one - both are one-shot latches.
+  if widget.source.gen ~= widget.sourceGen then
+    -- The source resolved LATE: it was absent when the widget was created (a
+    -- fresh model, after "delete all sensors", a new RX) and the throttled
+    -- retry in telemetry.refresh has just found it. resolveSource fills
+    -- widget.source, but everything DERIVED from it - unit text, name, the
+    -- Auto preset scale, precision, the layout - comes from configure(),
+    -- which otherwise only runs from update(). The firmware calls update()
+    -- "when the widget options have changed" (widget.h:109), not on a timer,
+    -- so without this an RPM sensor discovered a second after boot kept
+    -- drawing on the default 0..100 scale, nameless and unitless, until the
+    -- user happened to edit an option.
+    apply(widget, false)
+  elseif widget.config.battery == BATTERY_OFF and widget.source.cells
+         and not widget.cellsApplied then
+    -- a battery pack's cell count is only known after the first reading; when
+    -- it lands, the scale is rebuilt once
+    widget.cellsApplied = true
+    apply(widget, false)
+  end
+
+  -- EdgeTX/HTX does not guarantee widget.update() for a live theme switch.
+  -- The resolver therefore probes the small resolved-role signature at most
+  -- once per second and swaps only the palette table. bar.update() detects its
+  -- signature and recolors the existing tree in this same refresh.
+  if widget.layout.style == "bar" then
+    m.bar_style.refreshPalette(widget, widget.config)
+  end
+
+  m.alerts.update(widget)
+  painter(widget).update(widget)
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar.lua
@@ -1,0 +1,517 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - linear (bar) renderer                                      #
+---- #                                                                       #
+---- # Same data model, state colours and history as the dial; used when a   #
+---- # rotary dial cannot work: very wide/short zones, or Style = Bar.       #
+---- # A 40 px dial in a 200x50 slot is decoration, not an instrument.       #
+---- #                                                                       #
+---- # Retained rectangles, lines and chamfer triangles stay under the       #
+---- # Continuous face's measured object/instruction ceilings.               #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local abs, floor, max = math.abs, math.floor, math.max
+
+local T, G, F, R, Faces, Motion, BarStyle
+
+function M.setup(theme, geometry, format, renderer, faces, motion, barStyle)
+  T, G, F, R, Faces, Motion, BarStyle =
+    theme, geometry, format, renderer, faces, motion, barStyle
+  -- Source-edit text path: shared with the dial (Tanda 6 F-15). The bar has
+  -- no scale labels, so the shared helper's guarded fields no-op here. The
+  -- alias is assigned HERE - R is nil until setup runs.
+  M.updateSourceLabels = R.updateSourceLabels
+end
+
+local function markPosition(widget, value)
+  local cfg, axis = widget.config, widget.layout.axis
+  local normalized = G.normalize(value, cfg.min, cfg.max)
+  return axis.start + axis.growth * floor(axis.length * normalized + 0.5)
+end
+
+local function axisLine(axis, position, cross1, cross2, thickness, color,
+                        opacity)
+  local pts
+  if axis.orientation == "vertical" then
+    pts = { { cross1, position }, { cross2, position } }
+  else
+    pts = { { position, cross1 }, { position, cross2 } }
+  end
+  return lvgl.line{
+    pts = pts, thickness = thickness, color = color,
+    opacity = opacity or T.opacity.full,
+  }
+end
+
+-- A vertical mark that MOVES: its pts buffer and its { pts = ... } wrapper
+-- are created once and reused forever, the needle's Phase 5.1/5.2 contract
+-- applied to the two marks Phase 5 left behind. luaLvglSet parses the params
+-- table at call time and keeps no reference to it, and LvglWidgetLine::getPts
+-- copies the coordinates out, so mutating both in place is legal.
+-- NEVER route these through R.setProp: its cache compares tables by identity
+-- and would drop every write after the first (5.1/5.2 TRAP 2).
+-- The static threshold marks keep plain vline() above - they never move.
+local function movingMark(ui, key, axis, position, cross1, cross2, thickness,
+                          color, opacity)
+  local pts
+  if axis.orientation == "vertical" then
+    pts = { { cross1, position }, { cross2, position } }
+  else
+    pts = { { position, cross1 }, { position, cross2 } }
+  end
+  ui[key .. "Pts"] = pts
+  ui[key .. "Set"] = { pts = pts }
+  ui[key] = lvgl.line{
+    pts = pts, thickness = thickness, color = color,
+    opacity = opacity or T.opacity.full,
+  }
+  lvgl.hide(ui[key])
+end
+
+local function moveMark(ui, key, axis, position)
+  local pts = ui[key .. "Pts"]
+  local coordinate = (axis.orientation == "vertical") and 2 or 1
+  pts[1][coordinate], pts[2][coordinate] = position, position
+  lvgl.set(ui[key], ui[key .. "Set"])
+  lvgl.show(ui[key])
+end
+
+function M.build(widget)
+  local L, ui, cfg = widget.layout, widget.ui, widget.config
+  local b = L.bar
+  local visual = widget.barVisual or {
+    face = "continuous", profile = {}, segments = 10,
+  }
+  local face, fallback = Faces.select(visual.face, visual.profile, visual)
+  widget.barFace = face
+  widget.barFaceName = face.name
+  visual.faceFallback = fallback
+  if fallback then visual.downgrades[#visual.downgrades + 1] = fallback end
+  assert(face.build(widget, b, visual), "GaugePro: bar face build failed")
+  if BarStyle then
+    widget.limitNotice = BarStyle.syncNotices(visual, cfg)
+  end
+
+  -- threshold marks on the track, the linear equivalent of the dial's rail.
+  -- Compare the NORMALISED position, not the raw value against cfg.min/max:
+  -- on a descending scale (Min > Max) `r.to > cfg.min and r.to < cfg.max` is
+  -- never true, so every mark silently vanished (AUDIT.md P0-3). And mark the
+  -- BOUNDARY of EVERY band whose end falls strictly inside the scale, not
+  -- just the non-normal ones: on a low-is-good scale (normal -> warning ->
+  -- critical) the warning threshold is the `to` of the NORMAL band, so the
+  -- old condition drew only one mark where the dial draws two rails
+  -- (AUDIT.md P1-11).
+  local marksMode = visual.marks or "auto"
+  local showThresholds = marksMode == "thresholds" or marksMode == "full"
+    or (marksMode == "auto" and cfg.colorMode ~= R.COLOR_STATIC)
+  local showEnds = marksMode == "ends" or marksMode == "full"
+  if showThresholds then
+    ui.marks = {}
+    ui.markRoles = {}
+    for i = 1, #widget.ranges do
+      local r = widget.ranges[i]
+      local t = G.normalize(r.to, cfg.min, cfg.max)
+      if t > 0 and t < 1 then
+        local body, axis = L.barOuter or b, L.axis
+        local cross1 = (axis.orientation == "vertical") and body.x or body.y
+        local cross2 = cross1
+          + ((axis.orientation == "vertical") and body.w or body.h)
+        local m = axisLine(axis, markPosition(widget, r.to), cross1, cross2,
+          L.markThickness, T.stateColor(r.role, widget.accent,
+                                       widget.barPalette))
+        -- LVGL objects are opaque userdata on the radio (no __newindex), so
+        -- the role the repaint path needs rides in a parallel array instead
+        -- of on the object (Tanda 6 F-5).
+        ui.marks[#ui.marks + 1] = m
+        ui.markRoles[#ui.marks] = r.role
+      end
+    end
+  end
+
+  if showEnds then
+    ui.endMarks = {}
+    local body, axis = L.barOuter or b, L.axis
+    local cross1 = (axis.orientation == "vertical") and body.x or body.y
+    local cross2 = cross1
+      + ((axis.orientation == "vertical") and body.w or body.h)
+    for i = 1, 2 do
+      ui.endMarks[i] = axisLine(axis,
+        G.axisPoint(axis, (i == 1) and 0 or 1), cross1, cross2,
+        L.markThickness,
+        (widget.barPalette and widget.barPalette.label) or T.color.label,
+        T.opacity.railBand)
+    end
+  end
+
+  -- markOverhang comes from the layout, which RESERVED it in the vertical
+  -- budget: restating it here as px(2)/px(4) is what let the markers hang
+  -- past the bottom of a row-less short bar. It also fixes an asymmetry -
+  -- px(4) is not 2 * px(2) at LCD_SCALE 0.8, so the old line stuck out 2 px
+  -- above and only 1 px below on a 320 px screen.
+  local over = L.markOverhang
+  local body = L.barOuter or b
+  local axis = L.axis
+  local crossStart = (axis.orientation == "vertical")
+    and (body.x - over) or (body.y - over)
+  local crossEnd = (axis.orientation == "vertical")
+    and (body.x + body.w + over) or (body.y + body.h + over)
+  local crossMid = (axis.orientation == "vertical")
+    and (body.x + floor(body.w / 2)) or (body.y + floor(body.h / 2))
+  if L.showGhost then
+    movingMark(ui, "ghost", axis, axis.start, crossStart, crossEnd,
+               L.markThickness,
+               (widget.barPalette and widget.barPalette.history)
+                 or T.color.history, T.opacity.ghost)
+  end
+  if L.showMarkers then
+    -- Min and max are independent authored readings. Split their ticks around
+    -- the rail centre so coincident extrema remain distinguishable without
+    -- inventing a color meaning.
+    movingMark(ui, "minMark", axis, axis.start, crossStart, crossMid,
+               L.markThickness,
+               (widget.barPalette and widget.barPalette.history)
+                 or T.color.history)
+    movingMark(ui, "maxMark", axis, axis.start, crossMid, crossEnd,
+               L.markThickness,
+               (widget.barPalette and widget.barPalette.history)
+                 or T.color.history)
+  end
+
+  if visual.origin == "zero" then
+    movingMark(ui, "zeroMark", axis, axis.originCoord, crossStart, crossEnd,
+      max(L.markThickness, T.px(2)),
+      (widget.barPalette and widget.barPalette.label) or T.color.label,
+      T.opacity.full)
+    lvgl.show(ui.zeroMark)
+  end
+
+  assert(face.buildOverlay(widget, b, visual) ~= false,
+         "GaugePro: bar face overlay build failed")
+
+  -- DATA text takes the theme's ink role, not the status colour (Tanda 8
+  -- §3.2) - see renderer.valueColor.
+  local palette = widget.barPalette
+  if L.showValue ~= false then
+    ui.valueLabel = R.label(L.valueBox, L.valueFont,
+                            (palette and palette.value) or T.color.value,
+                            L.valueAlign, F.NO_VALUE)
+  end
+  if L.showUnit and widget.unitText ~= "" then
+    ui.unitLabel = R.label(L.unitBox, L.unitFont,
+                           (palette and palette.label) or T.color.label,
+                           L.unitAlign,
+                           widget.unitText)
+  end
+  if L.showName then
+    ui.nameLabel = R.label(L.nameBox, L.nameFont,
+                           (palette and palette.label) or T.color.label,
+                           L.nameAlign,
+                           widget.nameText)
+  end
+  if L.showMinMaxText then
+    -- Same captions, same history ink and same left/right split as the dial
+    -- (dial_renderer): a shared option has to read the same on both families.
+    local ink = (palette and palette.history) or T.color.history
+    ui.minText = R.label(L.minTextBox, L.minMaxFont, ink, LEFT)
+    ui.maxText = R.label(L.maxTextBox, L.minMaxFont, ink, RIGHT)
+  end
+  if L.showState then
+    -- the state chip: same pill as the dial, so WARN/CRIT/STALE signal
+    -- identically in bar zones (AUDIT.md P1-10). Text vertically centred and
+    -- a 1 px outline in the lighter label role (review P-B). The centring
+    -- offset is LAYOUT data (L.chipOff) - see renderer.build (Tanda 6 F-1).
+    local edge = L.chipOutline
+    ui.chipEdge = lvgl.rectangle{
+      x = L.stateBox.x - edge, y = L.stateBox.y - L.chipOff - edge,
+      w = L.stateBox.w + edge * 2, h = L.chipHeight + edge * 2,
+      color = (palette and palette.label) or T.color.label, filled = 1,
+      rounded = floor((L.chipHeight + edge * 2) / 2),
+    }
+    -- built muted, shown coloured: R.updateChip owns the fill and the ink
+    ui.chip = lvgl.rectangle{
+      x = L.stateBox.x, y = L.stateBox.y - L.chipOff,
+      w = L.stateBox.w, h = L.chipHeight,
+      color = (palette and palette.muted) or T.color.muted,
+      filled = 1, rounded = floor(L.chipHeight / 2),
+    }
+    lvgl.hide(ui.chipEdge)
+    lvgl.hide(ui.chip)
+    local muted = (palette and palette.muted) or T.color.muted
+    ui.stateLabel = R.label(L.stateBox, L.stateFont, T.labelOn(muted, palette),
+                            L.stateAlign)
+    lvgl.hide(ui.stateLabel)
+  end
+
+  local initialPaletteSig = palette and palette.signature
+  if ui.gradientSlices then initialPaletteSig = nil end
+  widget.frame = {
+    props = {},
+    dirty = {},
+    fillW = -1, fillStart = -1, fillLength = -1,
+    fillShown = false, headX = -1, headPos = -1, headShown = false,
+    gradientWhole = -1,
+    ghostX = -1, minX = -1, maxX = -1,
+    ghostPos = -1, minPos = -1, maxPos = -1,
+    needleShown = true, markersShown = false, chipShown = false,
+    colorKey = "", accentKey = nil, paletteSig = initialPaletteSig,
+    valueStr = "", stateStr = "",
+    minStr = "", maxStr = "",
+    prevAvail = "unset", pulse = false, pulseAt = 0,
+  }
+  Faces.buildRenderState(widget)
+  Motion.build(widget)
+  ui.built = true
+end
+
+local function updateHistory(widget)
+  local ui, frame = widget.ui, widget.frame
+  local h = widget.history
+  local historyGen = h.gen or 0
+  if frame.historyGen == historyGen then return end
+  frame.historyGen = historyGen
+  -- History changes far less often than telemetry. Gate on the authored
+  -- extrema before normalising/formatting them: the previous path recomputed
+  -- three axis positions and two strings on every moving frame even while the
+  -- extrema were unchanged. Ordering is used instead of mixed int/float `==`
+  -- for the same EdgeTX Lua-number reason as the segmented renderer.
+  local minSame = h.min ~= nil and frame.historyMin ~= nil
+    and h.min >= frame.historyMin and frame.historyMin >= h.min
+  local maxSame = h.max ~= nil and frame.historyMax ~= nil
+    and h.max >= frame.historyMax and frame.historyMax >= h.max
+  local minChanged = not minSame and (h.min ~= nil or frame.historyMin ~= nil)
+  local maxChanged = not maxSame and (h.max ~= nil or frame.historyMax ~= nil)
+  frame.historyMin, frame.historyMax = h.min, h.max
+  -- Both marks LEAVE when the history is cleared (the reset switch, a source
+  -- change, a range edit). They used to stay behind pointing at a peak that
+  -- no longer existed, and only corrected themselves on the next valid
+  -- reading - indefinitely, if the reset happened during a dropout. markX()
+  -- always returns at least L.bar.x (>= pad >= 1), so -1 is no real position
+  -- and doubles as the build-time "never placed" sentinel.
+  if ui.ghost then
+    if h.min and h.max then
+      -- peak-hold marker: the extreme of the SWEEP, which is h.min on a
+      -- descending scale (Min > Max) - h.max maps back onto the start there
+      -- and the ghost marked the tract never visited (Tanda 6 F-3). Both
+      -- bounds are required: readHistorySiblings can populate one alone, and
+      -- the descending peak picks either one (Tanda 6 F-8 hardens the guard).
+      local peak = (widget.config.max >= widget.config.min) and h.max or h.min
+      local peakSame = frame.historyPeak ~= nil
+        and peak >= frame.historyPeak and frame.historyPeak >= peak
+      if not peakSame then
+        frame.historyPeak = peak
+        local position = markPosition(widget, peak)
+        frame.ghostPos, frame.ghostX = position, position
+        moveMark(ui, "ghost", widget.layout.axis, position)
+      end
+    elseif frame.ghostX ~= -1 then
+      frame.historyPeak = nil
+      frame.ghostX, frame.ghostPos = -1, -1
+      lvgl.hide(ui.ghost)
+    end
+  end
+  if ui.minMark then
+    if h.min and minChanged then
+      local position = markPosition(widget, h.min)
+      frame.minPos, frame.minX = position, position
+      moveMark(ui, "minMark", widget.layout.axis, position)
+    elseif frame.minX ~= -1 then
+      if not h.min then
+        frame.minX, frame.minPos = -1, -1
+        lvgl.hide(ui.minMark)
+      end
+    end
+  end
+  if ui.maxMark then
+    if h.max and maxChanged then
+      local position = markPosition(widget, h.max)
+      frame.maxPos, frame.maxX = position, position
+      moveMark(ui, "maxMark", widget.layout.axis, position)
+    elseif frame.maxX ~= -1 then
+      if not h.max then
+        frame.maxX, frame.maxPos = -1, -1
+        lvgl.hide(ui.maxMark)
+      end
+    end
+  end
+  if ui.minText then
+    if minChanged then
+      local mn = h.min and F.display(widget, h.min) or ""
+      frame.minStr = mn
+      R.setProp(widget, ui.minText, "text",
+                (mn ~= "") and ("min " .. mn) or "")
+    end
+    if maxChanged then
+      local mx = h.max and F.display(widget, h.max) or ""
+      frame.maxStr = mx
+      R.setProp(widget, ui.maxText, "text",
+                (mx ~= "") and ("max " .. mx) or "")
+    end
+  end
+end
+
+-- Critical state pulses the exact-position head at ~1 Hz - never the fill, and
+-- never the dial's value arc, which both carry the reading itself
+-- (AUDIT.md P1-10 plus the 2026-08-11 contrast measurement). Shared helper
+-- (Tanda 6 F-15): the bar pulses ui.head, the dial pulses its state pill.
+
+function M.update(widget)
+  local ui, frame = widget.ui, widget.frame
+  if not ui.built then return end
+
+  local state = Faces.updateRenderState(widget)
+  local key = state.colorKey
+  local palette = widget.barPalette
+  local paletteSig = palette and palette.signature
+  local motion = widget.motionState
+  local paletteChanged = paletteSig ~= frame.paletteSig
+  local colorContextChanged = key ~= frame.colorKey
+    or widget.accent ~= frame.accentKey or paletteChanged
+  local expressiveTrigger = motion.expressive and motion.headArmed
+    and abs(state.rawNormalized - motion.rawNormalized) >= 0.08
+  local needsMotion = not motion.initialized or motion.requiresFrameMotion
+    or state.valid ~= motion.rawValid or state.state ~= motion.rawState
+    or widget.barVisual ~= motion.visualContract or paletteChanged
+    or expressiveTrigger
+  local targetColor = motion.targetColor
+  local motionPaintChanged
+  if needsMotion or colorContextChanged then
+    targetColor = R.resolveColor(widget, key, palette)
+  end
+  if needsMotion then
+    local beforeColor = state.visualColor
+    local beforeOpacity = state.opacity
+    local beforeHead = state.headBoost
+    local beforeSettle = state.settleLevel
+    local wasTemporal = motion.colorActive or motion.fadeActive
+      or motion.headActive
+    Motion.update(widget, state, targetColor, paletteSig)
+    motionPaintChanged = wasTemporal
+      or state.visualColor ~= beforeColor or state.opacity ~= beforeOpacity
+      or state.headBoost ~= beforeHead or state.settleLevel ~= beforeSettle
+  else
+    -- Hot retained path: all raw-state work and position damping already ran.
+    -- A stable semantic frame needs only the continuity timestamp and the
+    -- last truthful geometry used if a dropout begins on the next frame.
+    motion.lastAt = getTime()
+    if state.valid then
+      motion.lastNormalized = state.smoothNormalized
+      motion.lastValue = state.smoothValue
+      if motion.expressive
+         and abs(state.rawNormalized - motion.rawNormalized) < 0.02 then
+        motion.headArmed = true
+      end
+      motion.rawNormalized = state.rawNormalized
+    end
+    if colorContextChanged then
+      motion.targetColor, motion.visualColor = targetColor, targetColor
+      state.visualColor = targetColor
+    end
+    state.motionPaused = false
+  end
+  state.paletteChanged = paletteChanged
+  -- the accent is an input to the colour: see renderer.update (Tanda 6 F-5)
+  if colorContextChanged or motionPaintChanged then
+    frame.colorKey = key
+    frame.accentKey = widget.accent
+    frame.paletteSig = paletteSig
+    frame.visualColor = state.visualColor
+    frame.motionOpacity = state.opacity
+    frame.headBoost = state.headBoost
+    widget.barFace.applyPalette(widget, ui, palette, state)
+    if ui.marks then
+      -- threshold marks were painted at build time; the normal-boundary
+      -- mark carries the accent and must follow an accent edit (F-5).
+      -- F2: and they follow the fill into the muted state, so a bar with no
+      -- data does not keep three fully saturated threshold marks on it.
+      for i = 1, #ui.marks do
+        local m = ui.marks[i]
+        R.setProp(widget, m, "color",
+                  T.stateColor(ui.markRoles[i], widget.accent, palette))
+        R.setProp(widget, m, "opacity", state.opacity)
+        local assist = palette and palette.assist
+        local thickness = widget.layout.markThickness
+          + ((assist == "strong") and T.px(1) or 0)
+        R.setProp(widget, m, "thickness", thickness)
+      end
+    end
+    if ui.endMarks then
+      for i = 1, #ui.endMarks do
+        R.setProp(widget, ui.endMarks[i], "color", palette.label)
+        R.setProp(widget, ui.endMarks[i], "opacity",
+                  (state.colorKey == "muted") and state.opacity
+                    or T.opacity.railBand)
+      end
+    end
+    if ui.zeroMark then
+      R.setProp(widget, ui.zeroMark, "color", palette.label)
+      R.setProp(widget, ui.zeroMark, "opacity", T.opacity.full)
+    end
+    local historyColor = (palette and palette.history) or T.color.history
+    if ui.ghost then R.setProp(widget, ui.ghost, "color", historyColor) end
+    if ui.minMark then R.setProp(widget, ui.minMark, "color", historyColor) end
+    if ui.maxMark then R.setProp(widget, ui.maxMark, "color", historyColor) end
+    -- the badge's fill and ink belong to R.updateChip: see renderer.applyColors
+  end
+
+  -- `state.state` is already the raw semantic key. Avoid asking the shared
+  -- renderer to derive it a second time on every high-rate bar frame.
+  if state.state ~= frame.stateKey or paletteChanged then
+    R.applyStateInk(widget, palette)
+  end
+
+  local str = (widget.data.availability == "unset") and F.NO_VALUE
+    or F.display(widget, widget.data.displayValue)
+  if str ~= frame.valueStr then
+    frame.valueStr = str
+    R.setProp(widget, ui.valueLabel, "text", str)
+    R.anchorUnit(widget, str)
+  end
+  if ui.stateLabel then
+    -- State text can change only with semantic state or availability; value
+    -- motion inside one band must not re-run the label classifier.
+    local noticeReason = widget.limitNotice and widget.limitNotice.reason
+    if state.state ~= frame.chipState
+       or state.availability ~= frame.chipAvailability
+       or noticeReason ~= frame.chipNotice then
+      frame.chipState = state.state
+      frame.chipAvailability = state.availability
+      frame.chipNotice = noticeReason
+      local s = R.stateText(widget)
+      frame.stateStr = s
+      R.setProp(widget, ui.stateLabel, "text", s)
+      R.updateChip(widget, s, palette)
+    end
+  end
+
+  -- A palette/theme edit can recolor a visible badge without changing its
+  -- text, so its color gate cannot be the state string alone.
+  if paletteChanged and ui.stateLabel and frame.stateStr ~= "" then
+    R.updateChip(widget, frame.stateStr, palette)
+  end
+
+  widget.barFace.update(widget, ui, state)
+  updateHistory(widget)
+  if key == "critical" or frame.pulseActive then
+    -- Never the fill: dimming the data channel is what put the critical red
+    -- at 1.74:1 on a dark theme (bar_faces, continuousBuildOverlay). Each face
+    -- nominates its head; a face built without one pulses the state pill, the
+    -- other status-channel object, which CRIT keeps visible even with the chip
+    -- option off.
+    if not ui.pulseTargets and ui.chip then
+      ui.pulseTargets = { ui.chip, ui.chipEdge, ui.stateLabel }
+    end
+    if ui.pulseTargets then
+      R.updatePulse(widget, key, ui.pulseTargets, state.pulseMode,
+                    state.opacity, state.motionPaused)
+    end
+  end
+
+  R.flush(widget)
+  frame.prevAvail = widget.data.availability
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_faces.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_faces.lua
@@ -1,0 +1,1769 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - retained bar face contract                                #
+---- #                                                                       #
+---- # Face code receives normalized render state. It never reads sensors,   #
+---- # classifies alerts, owns labels/badges/history, or creates objects in  #
+---- # update(). Continuous, Blocks, Hex, Ticks, and Steps are production     #
+---- # faces, including signed Dual Rail on horizontal and vertical axes.     #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local T, G, R
+local floor, ceil, min, max = math.floor, math.ceil, math.min, math.max
+-- Forward-declared: the continuous face builds its surface long before the
+-- segmented helpers are defined, and it used to carry its own copy of this.
+-- Two copies meant a surface fix landed in one face and not the other.
+local buildPanel
+
+-- Hot-path variants for already-normalized render state. The public geometry
+-- helpers clamp arbitrary callers; face updates receive guaranteed 0..1 and
+-- avoid repeating tonumber/clamp work several times per frame.
+local function pointAt(axis, normalized)
+  return axis.start + axis.growth * floor(axis.length * normalized + 0.5)
+end
+
+local function spanAt(axis, fromPosition, toPosition)
+  local p1, p2 = pointAt(axis, fromPosition), pointAt(axis, toPosition)
+  if p1 > p2 then p1, p2 = p2, p1 end
+  if axis.orientation == "vertical" then
+    return axis.x, p1, axis.w, p2 - p1
+  end
+  return p1, axis.y, p2 - p1, axis.h
+end
+
+local GRADIENT_CEILING = 38
+local GRADIENT_SHARED_RESERVE = 11
+
+function M.setup(theme, geometry, renderer)
+  T, G, R = theme, geometry, renderer
+end
+
+local function unavailableSupports()
+  return false
+end
+
+local function unavailableBuild()
+  return false
+end
+
+local function unavailableUpdate() end
+local function unavailablePalette() end
+local function unavailableVisible() end
+
+local function continuousSupports(_profile, config)
+  return not config or config.direction == nil
+    or config.direction == "horizontal" or config.direction == "vertical"
+end
+
+-- Gradient is a SHARED rule, not a bar rule: slice budget, scale-position ->
+-- severity mapping and slice colour all live in the core so the dial's arc
+-- and this axis cannot drift into two meanings (ui_core, "spatial gradient").
+-- Re-exported here because the catalogue, the census and the tests address
+-- them through the face module.
+function M.gradientSliceCount(length, available)
+  return R.gradientSliceCount(length, available)
+end
+
+function M.gradientPosition(cfg, axisPosition)
+  return R.gradientPosition(cfg, axisPosition)
+end
+
+local function gradientFixedObjects(config, layout)
+  local count = 1 -- exact position head
+  if config and config.surface and config.surface ~= "transparent" then
+    count = count + 1
+  end
+  if config and config.ends == "chamfer" then
+    count = count + 4 -- three-piece track + authored-start tip
+  else
+    count = count + 1 -- one-piece track
+    -- The current one-pixel casing is a centre rectangle plus two bevel tips.
+    -- With no concrete layout (the estimator), reserve it conservatively.
+    if not layout or (layout.barEdge or 0) > 0 then count = count + 3 end
+  end
+  return count
+end
+
+local function gradientSharedObjects(widget)
+  local L, cfg = widget.layout, widget.config
+  local count = 1 -- value label
+  if L.showUnit and widget.unitText ~= "" then count = count + 1 end
+  if L.showName then count = count + 1 end
+  if L.showState then count = count + 3 end -- edge + fill + label
+  if L.showGhost then count = count + 1 end
+  if L.showMarkers then count = count + 2 end
+  if L.showMinMaxText then count = count + 2 end -- min + max captions
+  local marks = widget.barVisual and widget.barVisual.marks or "auto"
+  local thresholds = marks == "thresholds" or marks == "full"
+    or (marks == "auto" and cfg.colorMode ~= R.COLOR_STATIC)
+  if thresholds then
+    for i = 1, #widget.ranges do
+      local t = G.normalize(widget.ranges[i].to, cfg.min, cfg.max)
+      if t > 0 and t < 1 then count = count + 1 end
+    end
+  end
+  if marks == "ends" or marks == "full" then count = count + 2 end
+  if widget.barVisual and widget.barVisual.origin == "zero" then
+    count = count + 1
+  end
+  return count
+end
+
+local function continuousEstimate(profile, config)
+  if config and config.colorMode == R.COLOR_GRADIENT then
+    local fixed = gradientFixedObjects(config)
+    local available = GRADIENT_CEILING - GRADIENT_SHARED_RESERVE - fixed
+    local length = (profile and profile.w) or 300
+    return GRADIENT_SHARED_RESERVE + fixed
+      + M.gradientSliceCount(length, available)
+  end
+  local count = 7 -- casing + track + fill + exact head + three bands
+  if config and config.surface and config.surface ~= "transparent" then
+    count = count + 1
+  end
+  if config and config.ends == "chamfer" then count = count + 2 end
+  return count
+end
+
+local function shape(ui, key, rect, color, opacity, radius, bevel, orientation)
+  bevel = min(bevel or 0, floor((rect.w - 1) / 2), floor(rect.h / 2))
+  if bevel > 0 then
+    if orientation == "vertical" then
+      ui[key] = lvgl.rectangle{
+        x = rect.x, y = rect.y + bevel, w = rect.w,
+        h = max(1, rect.h - bevel * 2), color = color, opacity = opacity,
+        filled = 1, rounded = 0,
+      }
+      local midX = rect.x + floor(rect.w / 2)
+      ui[key .. "Caps"] = {
+        lvgl.triangle{
+          pts = { { rect.x, rect.y + bevel }, { midX, rect.y },
+                  { rect.x + rect.w, rect.y + bevel } },
+          color = color, opacity = opacity,
+        },
+        lvgl.triangle{
+          pts = { { rect.x, rect.y + rect.h - bevel },
+                  { rect.x + rect.w, rect.y + rect.h - bevel },
+                  { midX, rect.y + rect.h } },
+          color = color, opacity = opacity,
+        },
+      }
+    else
+      ui[key] = lvgl.rectangle{
+        x = rect.x + bevel, y = rect.y,
+        w = max(1, rect.w - bevel * 2), h = rect.h,
+        color = color, opacity = opacity, filled = 1, rounded = 0,
+      }
+      ui[key .. "Caps"] = {
+        lvgl.triangle{
+          pts = {
+            { rect.x + bevel, rect.y },
+            { rect.x + bevel, rect.y + rect.h },
+            { rect.x, rect.y + floor(rect.h / 2) },
+          },
+          color = color, opacity = opacity,
+        },
+        lvgl.triangle{
+          pts = {
+            { rect.x + rect.w - bevel, rect.y },
+            { rect.x + rect.w, rect.y + floor(rect.h / 2) },
+            { rect.x + rect.w - bevel, rect.y + rect.h },
+          },
+          color = color, opacity = opacity,
+        },
+      }
+    end
+  else
+    ui[key] = lvgl.rectangle{
+      x = rect.x, y = rect.y, w = rect.w, h = rect.h,
+      color = color, opacity = opacity, filled = 1, rounded = radius or 0,
+    }
+  end
+end
+
+local function setShapeProp(widget, ui, key, prop, value)
+  R.setProp(widget, ui[key], prop, value)
+  local caps = ui[key .. "Caps"]
+  if caps then
+    for i = 1, #caps do R.setProp(widget, caps[i], prop, value) end
+  end
+end
+
+local function showShape(ui, key, visible)
+  local fn = visible and lvgl.show or lvgl.hide
+  if ui[key] then fn(ui[key]) end
+  local caps = ui[key .. "Caps"]
+  if caps then for i = 1, #caps do fn(caps[i]) end end
+end
+
+local function bandSpan(axis, range, cfg)
+  local t1 = G.normalize(range.from, cfg.min, cfg.max)
+  local t2 = G.normalize(range.to, cfg.min, cfg.max)
+  return G.axisSpan(axis, t1, t2)
+end
+
+local function buildReferenceBands(widget, axis)
+  local ui, cfg, palette = widget.ui, widget.config, widget.barPalette
+  if cfg.colorMode ~= R.COLOR_RAIL and cfg.colorMode ~= R.COLOR_SECTIONS then
+    return
+  end
+  ui.rails = {}
+  ui.railMeta = {}
+  local railCross = max(1, min(T.px(3),
+    floor(axis.crossLength * 0.3)))
+  for i = 1, #widget.ranges do
+    local range = widget.ranges[i]
+    if cfg.colorMode == R.COLOR_SECTIONS or range.role ~= "normal" then
+      local x, y, w, h = bandSpan(axis, range, cfg)
+      if axis.orientation == "vertical" then
+        x, w = axis.x + axis.w - railCross, railCross
+      else
+        y, h = axis.y + axis.h - railCross, railCross
+      end
+      if w > 0 and h > 0 then
+        local opacity = (cfg.colorMode == R.COLOR_SECTIONS)
+          and T.opacity.ghost or T.opacity.railBand
+        local band = lvgl.rectangle{
+          x = x, y = y, w = w, h = h,
+          color = T.stateColor(range.role, widget.accent, palette),
+          opacity = opacity, filled = 1, rounded = 0,
+        }
+        -- LVGL objects are opaque userdata on the radio (no __newindex), so
+        -- the role/opacity the repaint path needs ride in a parallel array.
+        ui.rails[#ui.rails + 1] = band
+        ui.railMeta[#ui.railMeta + 1] = { role = range.role,
+                                          baseOpacity = opacity }
+      end
+    end
+  end
+end
+
+local function continuousBuild(widget, _geometry, style)
+  local L, ui = widget.layout, widget.ui
+  local b, outer = L.bar, L.barOuter or L.bar
+  local palette = widget.barPalette
+  local track = (palette and palette.track) or T.color.rail
+  local border = (palette and palette.border) or T.color.label
+  local bevel = (style.ends == "chamfer") and L.barChamfer or 0
+
+  -- Surface is intentionally first: every instrument object and every shared
+  -- label is created after it, so a theme/custom panel can ground the complete
+  -- widget without changing text geometry. One shared builder for every face.
+  buildPanel(widget, style)
+
+  -- Round/square bodies use a separate one-pixel casing. It must be a REAL
+  -- border, not a filled silhouette behind the translucent track: Contrast
+  -- Auto can raise the casing to full opacity and, on the stock theme, border
+  -- and track resolve to the same colour. A filled casing therefore makes the
+  -- entire inactive channel visually opaque even though the track itself is
+  -- correctly set to T.opacity.rail (W-03).
+  --
+  -- A true chamfer already needs three retained track primitives; omitting
+  -- its redundant second three-piece outline keeps the worst
+  -- surface+sections variant inside the approved 24-object Continuous budget.
+  if (L.barEdge or 0) > 0 and bevel == 0 then
+    ui.casing = lvgl.rectangle{
+      x = outer.x, y = outer.y, w = outer.w, h = outer.h,
+      color = border, opacity = T.opacity.railBand, filled = 0,
+      thickness = L.barEdge, rounded = L.barOuterRadius,
+    }
+  end
+  shape(ui, "track", b, track, T.opacity.rail, L.barRadius, bevel,
+        L.axis.orientation)
+
+  -- Chamfer tips are casing, not authored scale. Keeping the data axis in the
+  -- central body prevents a one-pixel fill from leaking into transparent
+  -- corners and makes threshold/head/history positions share one exact map.
+  local axis = L.axis
+  local active = L.activeAxis or axis
+  buildReferenceBands(widget, axis)
+
+  -- Shared threshold/history overlays are built after this body. The head is
+  -- built even later by continuousBuildOverlay, so the paint stack is always
+  -- body -> thresholds/history -> exact position head -> text/badge.
+  if widget.config.colorMode == R.COLOR_GRADIENT then
+    local fixed = gradientFixedObjects(style, L)
+    local available = GRADIENT_CEILING - gradientSharedObjects(widget) - fixed
+    local count = M.gradientSliceCount(axis.length, available)
+    ui.gradientSlices = {}
+    ui.sliceState = {}
+    style.gradientSlices = count
+    for i = 1, count do
+      local t1, t2 = (i - 1) / count, i / count
+      local x, y, w, h = G.axisSpan(active, t1, t2)
+      local slice = lvgl.rectangle{
+        x = x, y = y, w = max(1, w), h = max(1, h),
+        -- The first refresh paints the complete signature-keyed ramp. Keeping
+        -- build colour constant splits interpolation work out of the already
+        -- expensive structural callback without ever showing a wrong slice:
+        -- every slice remains hidden until that refresh sets its span.
+        color = (palette and palette.critical) or T.color.crit,
+        filled = 1, rounded = 0,
+      }
+      -- LVGL objects are opaque userdata on the radio (no __newindex), so all
+      -- per-slice geometry/visibility state lives in a parallel array. The
+      -- userdata back-reference stays here so show/set reach the object.
+      local sdata = {
+        object = slice,
+        fromPosition = t1, toPosition = t2,
+        baseX = x, baseY = y,
+        baseW = max(1, w), baseH = max(1, h),
+        paintX = x, paintY = y,
+        paintW = max(1, w), paintH = max(1, h),
+        barShown = false,
+      }
+      ui.sliceState[i] = sdata
+      lvgl.hide(slice)
+      ui.gradientSlices[i] = slice
+    end
+    -- Shared code and diagnostics continue to have one canonical fill handle;
+    -- the pulse target below owns the complete slice pool.
+    ui.fill = ui.gradientSlices[1]
+  else
+    local x, y, w, h = G.axisSpan(active, active.originT, active.originT)
+    ui.fill = lvgl.rectangle{
+      x = x, y = y, w = max(1, w), h = max(1, h),
+      color = (palette and palette.normal) or T.color.accent,
+      filled = 1,
+      rounded = (style.ends == "round")
+        and floor(active.crossLength / 2) or 0,
+    }
+    lvgl.hide(ui.fill)
+  end
+  if bevel > 0 and style.origin == "scale-low" then
+    local capColor = ui.gradientSlices
+      and ((palette and palette.critical) or T.color.crit)
+      or (palette and palette.normal) or T.color.accent
+    local capPts
+    if axis.orientation == "vertical" then
+      local midX = active.x + floor(active.w / 2)
+      capPts = { { active.x, active.y + active.h },
+        { b.x + b.w, active.y + active.h }, { midX, b.y + b.h } }
+    else
+      capPts = { { active.x, active.y },
+        { active.x, active.y + active.h },
+        { b.x, active.y + floor(active.h / 2) } }
+    end
+    ui.fillCap = lvgl.triangle{ pts = capPts, color = capColor }
+    lvgl.hide(ui.fillCap)
+  end
+  -- The critical pulse never dims the DATA. Modulating the fill's opacity put
+  -- the composite red at 1.74:1 against a dark theme at the trough - the most
+  -- urgent state rendered as the least visible thing on screen, and outside
+  -- the 3:1 floor every colour this widget paints has to clear. The segmented
+  -- faces already pulsed only their head; continuous and dual now do the same,
+  -- and bar.lua falls back to the state pill when a face has no head. The
+  -- target is attached by continuousBuildOverlay, once the head exists.
+  return true
+end
+
+local function movingHead(ui, key, axis, position, cross1, cross2, thickness,
+                          color, opacity)
+  local pts
+  if axis.orientation == "vertical" then
+    pts = { { cross1, position }, { cross2, position } }
+  else
+    pts = { { position, cross1 }, { position, cross2 } }
+  end
+  ui[key .. "Pts"] = pts
+  ui[key .. "Set"] = { pts = pts }
+  ui[key] = lvgl.line{
+    pts = pts, thickness = thickness, color = color, opacity = opacity,
+    rounded = 1,
+  }
+  lvgl.hide(ui[key])
+end
+
+local function buildPositionHead(widget)
+  local L, ui, axis = widget.layout, widget.ui, widget.layout.axis
+  local kind = (widget.barVisual and widget.barVisual.head) or "line"
+  ui.headKind = kind
+  if kind == "none" then return true end
+  local outer = L.barOuter or L.bar
+  local color = T.labelOn((widget.barPalette and widget.barPalette.normal)
+                            or T.color.accent, widget.barPalette)
+  local position = axis.start
+  if kind == "line" then
+    local cross1 = (axis.orientation == "vertical")
+      and (outer.x - T.px(1)) or (outer.y - T.px(1))
+    local cross2 = (axis.orientation == "vertical")
+      and (outer.x + outer.w + T.px(1)) or (outer.y + outer.h + T.px(1))
+    movingHead(ui, "head", axis, position, cross1, cross2, L.markThickness,
+               color, T.opacity.full)
+  elseif kind == "dot" then
+    local radius = max(T.px(2), floor(axis.crossLength * 0.28))
+    local cx = (axis.orientation == "vertical")
+      and (outer.x + floor(outer.w / 2)) or position
+    local cy = (axis.orientation == "vertical")
+      and position or (outer.y + floor(outer.h / 2))
+    ui.head = lvgl.circle{
+      x = cx, y = cy, radius = radius, color = color, filled = 1,
+      opacity = T.opacity.full,
+    }
+    ui.headSet = { [(axis.orientation == "vertical") and "y" or "x"] = position }
+    lvgl.hide(ui.head)
+  elseif kind == "cap" then
+    local thick = max(T.px(3), L.markThickness)
+    if axis.orientation == "vertical" then
+      ui.head = lvgl.rectangle{
+        x = outer.x, y = position - floor(thick / 2),
+        w = outer.w, h = thick, color = color, filled = 1,
+        rounded = floor(thick / 2), opacity = T.opacity.full,
+      }
+      ui.headSet = { y = position - floor(thick / 2) }
+    else
+      ui.head = lvgl.rectangle{
+        x = position - floor(thick / 2), y = outer.y,
+        w = thick, h = outer.h, color = color, filled = 1,
+        rounded = floor(thick / 2), opacity = T.opacity.full,
+      }
+      ui.headSet = { x = position - floor(thick / 2) }
+    end
+    ui.headHalf = floor(thick / 2)
+    lvgl.hide(ui.head)
+  else -- needle: a compact direction pointer contained inside the rail body
+    local half = max(T.px(2), floor(axis.crossLength * 0.3))
+    local low, high = min(axis.start, axis.endCoord), max(axis.start, axis.endCoord)
+    local p1, p2 = max(low, position - half), min(high, position + half)
+    local pts
+    if axis.orientation == "vertical" then
+      pts = { { outer.x, p1 }, { outer.x, p2 },
+              { outer.x + outer.w, position } }
+    else
+      pts = { { p1, outer.y }, { p2, outer.y },
+              { position, outer.y + outer.h } }
+    end
+    ui.headPts, ui.headSet, ui.headHalf = pts, { pts = pts }, half
+    ui.head = lvgl.triangle{
+      pts = pts, color = color, opacity = T.opacity.full,
+    }
+    ui.headKind = "needle"
+    lvgl.hide(ui.head)
+  end
+  return true
+end
+
+local function continuousBuildOverlay(widget)
+  local ok = buildPositionHead(widget)
+  -- Same rule as the segmented faces: pulse the exact-position head, never the
+  -- fill. With Head = None there is nothing here to pulse and bar.lua falls
+  -- back to the state pill.
+  widget.ui.pulseTargets = widget.ui.head and { widget.ui.head } or nil
+  return ok
+end
+
+local function moveHead(ui, key, axis, position)
+  if not ui[key] then return end
+  local kind = ui.headKind or "line"
+  if kind == "dot" then
+    local prop = (axis.orientation == "vertical") and "y" or "x"
+    ui.headSet[prop] = position
+    lvgl.set(ui[key], ui.headSet)
+    lvgl.show(ui[key])
+    return
+  elseif kind == "cap" then
+    local prop = (axis.orientation == "vertical") and "y" or "x"
+    ui.headSet[prop] = position - ui.headHalf
+    lvgl.set(ui[key], ui.headSet)
+    lvgl.show(ui[key])
+    return
+  elseif kind == "needle" then
+    local pts, half = ui.headPts, ui.headHalf
+    local coordinate = (axis.orientation == "vertical") and 2 or 1
+    local low, high = min(axis.start, axis.endCoord), max(axis.start, axis.endCoord)
+    pts[1][coordinate], pts[2][coordinate], pts[3][coordinate] =
+      max(low, position - half), min(high, position + half), position
+    lvgl.set(ui[key], ui.headSet)
+    lvgl.show(ui[key])
+    return
+  end
+  local pts = ui[key .. "Pts"]
+  local coordinate = (axis.orientation == "vertical") and 2 or 1
+  pts[1][coordinate], pts[2][coordinate] = position, position
+  lvgl.set(ui[key], ui[key .. "Set"])
+  lvgl.show(ui[key])
+end
+
+local function showSlice(sdata, shown)
+  if sdata.barShown == shown then return end
+  sdata.barShown = shown
+  if shown then lvgl.show(sdata.object) else lvgl.hide(sdata.object) end
+end
+
+local function hideGradient(objects)
+  for i = 1, #objects.gradientSlices do
+    showSlice(objects.sliceState[i], false)
+  end
+end
+
+local function setSliceGeometry(widget, sdata, x, y, w, h)
+  if widget.layout.axis.orientation == "vertical" then
+    if y ~= sdata.paintY then
+      sdata.paintY = y; R.setProp(widget, sdata.object, "y", y)
+    end
+    if h ~= sdata.paintH then
+      sdata.paintH = h; R.setProp(widget, sdata.object, "h", h)
+    end
+  else
+    if x ~= sdata.paintX then
+      sdata.paintX = x; R.setProp(widget, sdata.object, "x", x)
+    end
+    if w ~= sdata.paintW then
+      sdata.paintW = w; R.setProp(widget, sdata.object, "w", w)
+    end
+  end
+end
+
+-- Fast prefix path for the overwhelmingly common Scale-low origin. Only a
+-- crossed slice boundary walks the pool; motion within a slice touches that
+-- one slice. This preserves the Phase 4 ordinary-frame budget.
+local function updateGradientPrefix(widget, objects, normalized)
+  local slices, states = objects.gradientSlices, objects.sliceState
+  local frame = widget.frame
+  local axis = widget.layout.activeAxis or widget.layout.axis
+  local vertical = axis.orientation == "vertical"
+  local count = #slices
+  local whole = (normalized >= 1) and count or floor(normalized * count)
+  local current = (whole < count) and (whole + 1) or nil
+  local oldWhole = frame.gradientWhole
+  if whole ~= oldWhole then
+    frame.gradientWhole = whole
+    for i = 1, count do
+      local sdata = states[i]
+      if i <= whole then
+        if vertical then
+          if sdata.paintY ~= sdata.baseY then
+            sdata.paintY = sdata.baseY
+            R.setProp(widget, sdata.object, "y", sdata.baseY)
+          end
+          if sdata.paintH ~= sdata.baseH then
+            sdata.paintH = sdata.baseH
+            R.setProp(widget, sdata.object, "h", sdata.baseH)
+          end
+        else
+          if sdata.paintW ~= sdata.baseW then
+            sdata.paintW = sdata.baseW
+            R.setProp(widget, sdata.object, "w", sdata.baseW)
+          end
+        end
+        showSlice(sdata, true)
+      elseif i == current and normalized > sdata.fromPosition then
+        local position = pointAt(axis, normalized)
+        local length
+        if vertical then
+          length = sdata.baseY + sdata.baseH - position
+          if length > 0 then
+            if position ~= sdata.paintY then
+              sdata.paintY = position
+              R.setProp(widget, sdata.object, "y", position)
+            end
+            if length ~= sdata.paintH then
+              sdata.paintH = length
+              R.setProp(widget, sdata.object, "h", length)
+            end
+          end
+        else
+          length = position - sdata.baseX
+          if length > 0 and length ~= sdata.paintW then
+            sdata.paintW = length
+            R.setProp(widget, sdata.object, "w", length)
+          end
+        end
+        if length > 0 then
+          showSlice(sdata, true)
+        else
+          showSlice(sdata, false)
+        end
+      else
+        showSlice(sdata, false)
+      end
+    end
+  elseif current then
+    local sdata = states[current]
+    if normalized > sdata.fromPosition then
+      local position = pointAt(axis, normalized)
+      local length
+      if vertical then
+        length = sdata.baseY + sdata.baseH - position
+        if length > 0 then
+          if position ~= sdata.paintY then
+            sdata.paintY = position
+            R.setProp(widget, sdata.object, "y", position)
+          end
+          if length ~= sdata.paintH then
+            sdata.paintH = length
+            R.setProp(widget, sdata.object, "h", length)
+          end
+        end
+      else
+        length = position - sdata.baseX
+        if length > 0 and length ~= sdata.paintW then
+          sdata.paintW = length
+          R.setProp(widget, sdata.object, "w", length)
+        end
+      end
+      if length > 0 then
+        showSlice(sdata, true)
+      else
+        showSlice(sdata, false)
+      end
+    else
+      showSlice(sdata, false)
+    end
+  end
+end
+
+local function spanIndices(lo, hi, count)
+  if hi <= lo then return nil, nil end
+  local first = min(count, floor(lo * count) + 1)
+  local last = max(1, min(count, ceil(hi * count)))
+  return first, last
+end
+
+local function updateGradientIndex(widget, states, axis, index, lo, hi)
+  if not index then return end
+  local sdata = states[index]
+  local a, b = max(lo, sdata.fromPosition), min(hi, sdata.toPosition)
+  if b <= a then
+    showSlice(sdata, false)
+    return
+  end
+  local x, y, w, h = spanAt(axis, a, b)
+  if w <= 0 or h <= 0 then
+    showSlice(sdata, false)
+    return
+  end
+  setSliceGeometry(widget, sdata, x, y, w, h)
+  showSlice(sdata, true)
+end
+
+-- Retained arbitrary-span path for numeric-zero origin. The original version
+-- rescanned every gradient slice on every frame. A centred stick only moves
+-- two interval boundaries, so cache the old interval and touch the crossed
+-- slices plus the old/new boundary slices. A full walk now happens only on
+-- first paint or a genuine sign-crossing transition.
+local function updateGradientSpan(widget, objects, fromT, toT)
+  local slices, states = objects.gradientSlices, objects.sliceState
+  local frame = widget.frame
+  local axis = widget.layout.activeAxis or widget.layout.axis
+  local lo, hi = fromT, toT
+  if lo > hi then lo, hi = hi, lo end
+  local first, last = spanIndices(lo, hi, #slices)
+  local oldFirst, oldLast = frame.gradientFirst, frame.gradientLast
+
+  if oldFirst and not first then
+    for i = oldFirst, oldLast do showSlice(states[i], false) end
+  elseif first and not oldFirst then
+    for i = first, last do
+      updateGradientIndex(widget, states, axis, i, lo, hi)
+    end
+  elseif first then
+    if first > oldFirst then
+      for i = oldFirst, min(first - 1, oldLast) do
+        showSlice(states[i], false)
+      end
+    elseif first < oldFirst then
+      for i = first, min(oldFirst - 1, last) do
+        updateGradientIndex(widget, states, axis, i, lo, hi)
+      end
+    end
+    if last < oldLast then
+      for i = max(last + 1, oldFirst), oldLast do
+        showSlice(states[i], false)
+      end
+    elseif last > oldLast then
+      for i = max(oldLast + 1, first), last do
+        updateGradientIndex(widget, states, axis, i, lo, hi)
+      end
+    end
+
+    -- A former partial boundary becomes a full interior slice when its index
+    -- changes. Restore it before painting the new partial boundary.
+    if oldFirst ~= first and oldFirst >= first and oldFirst <= last then
+      updateGradientIndex(widget, states, axis, oldFirst, lo, hi)
+    end
+    if oldLast ~= last and oldLast >= first and oldLast <= last then
+      updateGradientIndex(widget, states, axis, oldLast, lo, hi)
+    end
+    updateGradientIndex(widget, states, axis, first, lo, hi)
+    if last ~= first then
+      updateGradientIndex(widget, states, axis, last, lo, hi)
+    end
+  end
+  frame.gradientFirst, frame.gradientLast = first, last
+  frame.gradientWhole = first and (last - first + 1) or 0
+end
+
+local function continuousUpdate(widget, objects, state)
+  local frame = widget.frame
+  if not state.visualValid then
+    if frame.fillShown then
+      frame.fillShown = false
+      if objects.gradientSlices then
+        hideGradient(objects)
+        frame.gradientWhole = -1
+      else
+        lvgl.hide(objects.fill)
+      end
+      if objects.fillCap then lvgl.hide(objects.fillCap) end
+    end
+    if frame.headShown and objects.head then
+      frame.headShown = false
+      lvgl.hide(objects.head)
+    end
+    return
+  end
+  local axis = widget.layout.axis
+  local active = widget.layout.activeAxis or axis
+  local normalized = state.smoothNormalized
+  local fromT, toT
+  if normalized < axis.originT then
+    fromT, toT = normalized, axis.originT
+  else
+    fromT, toT = axis.originT, normalized
+  end
+  local x, y, w, h = spanAt(active, fromT, toT)
+  local length = (axis.orientation == "vertical") and h or w
+  local shown = length > 0
+  if shown ~= frame.fillShown then
+    frame.fillShown = shown
+    if shown then
+      if not objects.gradientSlices then lvgl.show(objects.fill) end
+      if objects.fillCap then lvgl.show(objects.fillCap) end
+    else
+      if objects.gradientSlices then
+        hideGradient(objects)
+        frame.gradientWhole = -1
+      else
+        lvgl.hide(objects.fill)
+      end
+      if objects.fillCap then lvgl.hide(objects.fillCap) end
+    end
+  end
+  if objects.gradientSlices then
+    if axis.prefixOrigin then
+      updateGradientPrefix(widget, objects, normalized)
+    else
+      updateGradientSpan(widget, objects, fromT, toT)
+    end
+    frame.fillW = length
+  else
+    local start = (axis.orientation == "vertical") and y or x
+    if start ~= frame.fillStart or length ~= frame.fillLength then
+      frame.fillStart, frame.fillLength = start, length
+      frame.fillW = length
+      R.setProp(widget, objects.fill, "x", x)
+      R.setProp(widget, objects.fill, "y", y)
+      R.setProp(widget, objects.fill, "w", max(1, w))
+      R.setProp(widget, objects.fill, "h", max(1, h))
+    end
+  end
+  local position = pointAt(axis, normalized)
+  if objects.head and position ~= frame.headPos then
+    frame.headPos, frame.headX = position, position
+    moveHead(objects, "head", axis, position)
+    frame.headShown = true
+  elseif objects.head and not frame.headShown then
+    frame.headShown = true
+    lvgl.show(objects.head)
+  end
+end
+
+local function continuousPalette(widget, objects, palette, state)
+  if state.paletteChanged then
+    if objects.panel then R.setProp(widget, objects.panel, "color", palette.panel) end
+    setShapeProp(widget, objects, "casing", "color", palette.border)
+    setShapeProp(widget, objects, "track", "color", palette.track)
+  end
+  local assist = palette.assist
+  local assisted = assist == "needed" or assist == "strong"
+  local casingOpacity = assisted and T.opacity.full or T.opacity.railBand
+  local trackOpacity = (assist == "strong") and T.opacity.railBand
+    or assisted and min(T.opacity.full, T.opacity.rail + 60) or T.opacity.rail
+  setShapeProp(widget, objects, "casing", "opacity", casingOpacity)
+  setShapeProp(widget, objects, "track", "opacity", trackOpacity)
+  if objects.rails then
+    for i = 1, #objects.rails do
+      local rail = objects.rails[i]
+      local meta = objects.railMeta[i]
+      R.setProp(widget, rail, "color",
+                T.stateColor(meta.role, widget.accent, palette))
+      R.setProp(widget, rail, "opacity",
+                (state.colorKey == "muted") and T.opacity.muted
+                  or meta.baseOpacity)
+    end
+  end
+  local fill = state.visualColor or R.resolveColor(widget, state.colorKey, palette)
+  if objects.gradientSlices then
+    if state.paletteChanged then
+      local sliceCount = #objects.gradientSlices
+      local states = objects.sliceState
+      for i = 1, #objects.gradientSlices do
+        local slice = objects.gradientSlices[i]
+        local sdata = states[i]
+        if sdata.gradientT == nil then
+          local sample = (i == 1) and 0
+            or (i == sliceCount) and 1
+            or ((sdata.fromPosition + sdata.toPosition) * 0.5)
+          sdata.gradientT = M.gradientPosition(widget.config, sample)
+        end
+        local sliceColor
+        if sdata.gradientT <= 0 then sliceColor = palette.critical
+        elseif sdata.gradientT >= 1 then sliceColor = palette.normal
+        elseif sdata.gradientT == 0.5 then sliceColor = palette.warning
+        else sliceColor = T.paletteColor(palette, sdata.gradientT, 24) end
+        R.setProp(widget, slice, "color",
+                  sliceColor)
+      end
+    end
+  else
+    R.setProp(widget, objects.fill, "color", fill)
+  end
+  if state.opacity ~= widget.frame.faceOpacity then
+    widget.frame.faceOpacity = state.opacity
+    if objects.gradientSlices then
+      for i = 1, #objects.gradientSlices do
+        R.setProp(widget, objects.gradientSlices[i], "opacity", state.opacity)
+      end
+    else
+      R.setProp(widget, objects.fill, "opacity", state.opacity)
+    end
+  end
+  if objects.fillCap then
+    local capColor = objects.gradientSlices
+      and palette.critical
+      or fill
+    R.setProp(widget, objects.fillCap, "color", capColor)
+    if state.opacity ~= widget.frame.fillCapOpacity then
+      widget.frame.fillCapOpacity = state.opacity
+      R.setProp(widget, objects.fillCap, "opacity", state.opacity)
+    end
+  end
+  R.setProp(widget, objects.head, "color", T.labelOn(fill, palette))
+  R.setProp(widget, objects.head, "opacity", state.opacity)
+  local headThickness = widget.layout.markThickness
+    + ((assist == "strong") and T.px(2) or assisted and T.px(1) or 0)
+    + (((state.headBoost or 0) > 0) and T.px(state.headBoost) or 0)
+  if objects.headKind == "line" then
+    R.setProp(widget, objects.head, "thickness", headThickness)
+  end
+end
+
+local function continuousVisible(objects, visible)
+  local fn = visible and lvgl.show or lvgl.hide
+  if objects.panel then fn(objects.panel) end
+  showShape(objects, "casing", visible)
+  showShape(objects, "track", visible)
+  if objects.rails then for i = 1, #objects.rails do fn(objects.rails[i]) end end
+  if objects.gradientSlices then
+    if not visible then hideGradient(objects) end
+  else
+    fn(objects.fill)
+  end
+  if objects.fillCap then fn(objects.fillCap) end
+  if objects.head then fn(objects.head) end
+end
+
+-- ------------------------------------------------------- segmented faces --
+
+local function segmentedSupports(_profile, config)
+  return not config or config.direction == nil
+    or config.direction == "horizontal" or config.direction == "vertical"
+end
+
+-- Whole segments plus the truthful fraction of the current segment. Ticks
+-- and Steps pass partial=false and use the exact retained head for precision.
+function M.segmentProgress(count, normalized, partial)
+  count = max(1, floor(tonumber(count) or 1))
+  normalized = max(0, min(1, tonumber(normalized) or 0))
+  if normalized >= 1 then return count, 0 end
+  local scaled = normalized * count
+  local whole = floor(scaled)
+  return whole, partial and (scaled - whole) or 0
+end
+
+local function addDowngrade(style, reason)
+  if not style or not style.downgrades then return end
+  for i = 1, #style.downgrades do
+    if style.downgrades[i] == reason then return end
+  end
+  style.downgrades[#style.downgrades + 1] = reason
+end
+
+function buildPanel(widget, style)
+  if style.surface == "transparent" then return end
+  local L, palette = widget.layout, widget.barPalette
+  -- A panel the same colour as the screen behind it is an invisible object
+  -- that still costs a build slot and a full-zone fill every frame. On the
+  -- stock theme that is exactly what "Theme panel" was: palette.panel is
+  -- COLOR_THEME_SECONDARY3, which IS the home screen's background. Give it a
+  -- real edge instead of painting nothing - the border role is already in the
+  -- palette and is the same one the casing uses.
+  local color = (palette and palette.panel) or COLOR_THEME_SECONDARY3
+  local backdrop = palette and palette.backdrop
+  local rounded = min(T.px(8), floor(min(L.w, L.h) / 8))
+  if backdrop and color == backdrop and style.surface ~= "custom" then
+    widget.ui.panel = lvgl.rectangle{
+      x = 0, y = 0, w = L.w, h = L.h,
+      color = (palette and palette.border) or COLOR_THEME_SECONDARY1,
+      opacity = T.opacity.rail, filled = 0, thickness = T.px(1),
+      rounded = rounded,
+    }
+    return
+  end
+  widget.ui.panel = lvgl.rectangle{
+    x = 0, y = 0, w = L.w, h = L.h,
+    color = color,
+    opacity = T.opacity.full, filled = 1,
+    rounded = rounded,
+  }
+end
+
+local function gapPixels(style)
+  if style.gap == "wide" then return T.px(5) end
+  if style.gap == "tight" then return T.px(2) end
+  return T.px(3)
+end
+
+local function budgetedCount(widget, style, ceiling, perCell,
+                              minimum, maximum, geometryCap)
+  local fixed = 1 -- exact retained head
+  if style.surface ~= "transparent" then fixed = fixed + 1 end
+  local available = ceiling - gradientSharedObjects(widget) - fixed
+  local budgetCap = max(1, floor(available / perCell))
+  local requested = max(minimum, min(maximum, style.segments or minimum))
+  local count = min(requested, budgetCap, geometryCap or maximum)
+  count = max(1, count)
+  if count < requested then addDowngrade(style, "segments-whole-tree-budget") end
+  style.renderedSegments = count
+  return count
+end
+
+local function slotGeometry(axis, index, count, gap)
+  local t1, t2 = (index - 1) / count, index / count
+  local x, y, w, h = G.axisSpan(axis, t1, t2)
+  local length = (axis.orientation == "vertical") and h or w
+  local trailing = (index < count) and min(gap, max(0, length - 1)) or 0
+  if axis.orientation == "vertical" then
+    -- The physical trailing edge for a bottom-to-top axis is its top edge.
+    y, h = y + trailing, max(1, h - trailing)
+  else
+    w = max(1, w - trailing)
+  end
+  return x, y, w, h, t1, t2
+end
+
+local function roleBands(widget)
+  local bands = {}
+  for i = 1, #widget.ranges do
+    local range = widget.ranges[i]
+    local a = G.normalize(range.from, widget.config.min, widget.config.max)
+    local b = G.normalize(range.to, widget.config.min, widget.config.max)
+    if a > b then a, b = b, a end
+    local n = #bands
+    bands[n + 1], bands[n + 2], bands[n + 3] = a, b, range.role
+  end
+  return bands
+end
+
+local function roleAt(bands, position)
+  for i = 1, #bands, 3 do
+    if position >= bands[i]
+       and (position < bands[i + 1] or i == #bands - 2) then
+      return bands[i + 2]
+    end
+  end
+  return "normal"
+end
+
+local function spatialColor(widget, palette, position)
+  return R.spatialColor(widget.config, palette, position)
+end
+
+local function paintCell(cell, stateOpacity)
+  local fraction = cell.fraction
+  local active = fraction > 0
+  local color = active and cell.activeColor or cell.referenceColor
+  local base = cell.baseOpacity
+  local opacity
+  -- `fraction >= 1` / `not active`, never `== 1` / `== 0`: the firmware floors
+  -- a float before comparing it with an integer literal, so `0.45 == 0` was
+  -- true here and every PARTIAL cell painted itself as an inactive ghost
+  -- (G.isZero documents the mechanism).
+  if stateOpacity == T.opacity.full and fraction >= 1 then
+    opacity = T.opacity.full
+  elseif stateOpacity == T.opacity.full and not active then
+    opacity = base
+  else
+    local logical = base + floor((T.opacity.full - base) * fraction + 0.5)
+    opacity = floor(logical * stateOpacity / T.opacity.full + 0.5)
+  end
+  if cell.paintColor == color and cell.paintOpacity == opacity then return end
+  cell.paintColor, cell.paintOpacity = color, opacity
+  local props = cell.paintProps
+  props.color, props.opacity = color, opacity
+  -- Cell parts always change color and opacity together. Their retained
+  -- two-key table avoids two renderer-cache walks per part and allocates
+  -- nothing while a fast telemetry source moves.
+  lvgl.set(cell.primary, props)
+  if cell.parts then
+    -- The only multipart cell is the true hex: center plus two tips.
+    lvgl.set(cell.parts[2], props)
+    lvgl.set(cell.parts[3], props)
+  end
+end
+
+local function setCellFraction(cell, fraction, stateOpacity, force)
+  -- Ordering, not equality: callers pass the integer 0/1 for the common ends
+  -- and a float in between, and a mixed `==` floors on this firmware - so a
+  -- cell holding 0.45 compared equal to an incoming 0 and the repaint was
+  -- skipped. Two `<` are exact for every pair (see G.isZero).
+  local held = cell.fraction
+  if not force and held >= fraction and fraction >= held then return end
+  cell.fraction = fraction
+  paintCell(cell, stateOpacity)
+end
+
+local function baseOpacity(widget, cell, palette)
+  local mode = widget.config.colorMode
+  local opacity
+  if mode == R.COLOR_RAIL and cell.role ~= "normal" then
+    opacity = (cell.role == "critical")
+      and T.opacity.railBandCrit or T.opacity.railBand
+  elseif mode == R.COLOR_SECTIONS or mode == R.COLOR_GRADIENT then
+    opacity = T.opacity.ghost
+  else
+    opacity = T.opacity.rail
+  end
+  if palette.assist == "strong" then
+    opacity = max(28, floor(opacity * 0.55))
+  elseif palette.assist == "needed" then
+    opacity = max(36, floor(opacity * 0.75))
+  end
+  if cell.variant == "major" then
+    opacity = max(opacity, T.opacity.tickMajor)
+  elseif cell.variant == "minor" then
+    opacity = max(opacity, T.opacity.tickMinor)
+  end
+  return opacity
+end
+
+local function colorsForCell(widget, cell, palette, fill)
+  local mode = widget.config.colorMode
+  local semantic = T.stateColor(cell.role, widget.accent, palette)
+  if mode == R.COLOR_GRADIENT then
+    local spatial = spatialColor(widget, palette, cell.position)
+    return spatial, spatial
+  elseif mode == R.COLOR_SECTIONS then
+    return semantic, semantic
+  elseif mode == R.COLOR_RAIL and cell.role ~= "normal" then
+    return semantic, fill
+  end
+  return palette.track, fill
+end
+
+local function segmentedPalette(widget, objects, palette, state)
+  local paletteChanged = objects.segmentPaletteSig ~= palette.signature
+  local fill = state.visualColor or R.resolveColor(widget, state.colorKey, palette)
+  local colorChanged = objects.segmentColor ~= fill
+  objects.segmentPaletteSig = palette.signature
+  objects.segmentColorKey = state.colorKey
+  objects.segmentColor = fill
+  if objects.panel and paletteChanged then
+    R.setProp(widget, objects.panel, "color", palette.panel)
+  end
+  local stateColored = widget.config.colorMode ~= R.COLOR_GRADIENT
+    and widget.config.colorMode ~= R.COLOR_SECTIONS
+  -- The cell loop is the dominant ordinary-frame tax on true Hex (three LVGL
+  -- primitives per cell). Palette and semantic fill are normally stable, so
+  -- do not scan a retained array merely to take neither branch ten times.
+  if paletteChanged or (colorChanged and stateColored) then
+    for i = 1, #objects.faceCells do
+      local cell = objects.faceCells[i]
+      if paletteChanged then
+        if not cell.role then
+          cell.role = roleAt(objects.faceRoleBands, cell.position)
+        end
+        cell.referenceColor, cell.activeColor = colorsForCell(
+          widget, cell, palette, fill)
+        cell.baseOpacity = baseOpacity(widget, cell, palette)
+      else
+        cell.activeColor = fill
+      end
+    end
+  end
+  objects.repaintAll = paletteChanged
+  objects.repaintActive = colorChanged and stateColored and not paletteChanged
+  R.setProp(widget, objects.head, "color", T.labelOn(fill, palette))
+  R.setProp(widget, objects.head, "opacity", state.opacity)
+  local assisted = palette.assist == "needed" or palette.assist == "strong"
+  local headThickness = widget.layout.markThickness
+    + ((palette.assist == "strong") and T.px(2)
+       or assisted and T.px(1) or 0)
+    + (((state.headBoost or 0) > 0) and T.px(state.headBoost) or 0)
+    + (((state.settleLevel or 0) > 0) and T.px(state.settleLevel) or 0)
+  if objects.headKind == "line" then
+    R.setProp(widget, objects.head, "thickness", headThickness)
+  end
+end
+
+local function segmentedBuildOverlay(widget)
+  local ui = widget.ui
+  buildPositionHead(widget)
+  -- Segments remain visible to provide their reference scale, so pulsing their
+  -- opacity would destroy partial-cell and inactive-state truth. The exact
+  -- head is the retained, color-independent critical pulse target.
+  ui.pulseTargets = ui.head and { ui.head } or nil
+  return true
+end
+
+local function updatePartialIndex(cells, index, lo, hi, stateOpacity)
+  local cell = cells[index]
+  local a, b = max(lo, cell.fromPosition), min(hi, cell.toPosition)
+  local fraction = (b > a) and ((b - a)
+    / (cell.toPosition - cell.fromPosition)) or 0
+  setCellFraction(cell, fraction, stateOpacity)
+end
+
+local function updatePartialCells(widget, objects, normalized, stateOpacity)
+  local cells, frame = objects.faceCells, widget.frame
+  local axis = widget.layout.axis
+  if axis.prefixOrigin then
+    local scaled = normalized * #cells
+    local whole = (normalized >= 1) and #cells or floor(scaled)
+    local partial = (whole < #cells) and (scaled - whole) or 0
+    local oldWhole = frame.segmentWhole
+    if oldWhole == nil then
+      for i = 1, #cells do
+        local fraction = (i <= whole) and 1
+          or (i == whole + 1) and partial or 0
+        setCellFraction(cells[i], fraction, stateOpacity)
+      end
+    elseif whole > oldWhole then
+      for i = oldWhole + 1, whole do
+        setCellFraction(cells[i], 1, stateOpacity)
+      end
+    elseif whole < oldWhole then
+      local last = min(#cells, oldWhole + 1)
+      for i = whole + 2, last do
+        setCellFraction(cells[i], 0, stateOpacity)
+      end
+    end
+    if whole < #cells then
+      setCellFraction(cells[whole + 1], partial, stateOpacity)
+    end
+    frame.segmentWhole = whole
+    return
+  end
+  local lo, hi = normalized, axis.originT
+  if lo > hi then lo, hi = hi, lo end
+  local first, last = spanIndices(lo, hi, #cells)
+  local oldFirst, oldLast = frame.segmentFirst, frame.segmentLast
+  if oldFirst and not first then
+    for i = oldFirst, oldLast do setCellFraction(cells[i], 0, stateOpacity) end
+  elseif first and not oldFirst then
+    for i = first, last do
+      updatePartialIndex(cells, i, lo, hi, stateOpacity)
+    end
+  elseif first then
+    if first > oldFirst then
+      for i = oldFirst, min(first - 1, oldLast) do
+        setCellFraction(cells[i], 0, stateOpacity)
+      end
+    elseif first < oldFirst then
+      for i = first, min(oldFirst - 1, last) do
+        updatePartialIndex(cells, i, lo, hi, stateOpacity)
+      end
+    end
+    if last < oldLast then
+      for i = max(last + 1, oldFirst), oldLast do
+        setCellFraction(cells[i], 0, stateOpacity)
+      end
+    elseif last > oldLast then
+      for i = max(oldLast + 1, first), last do
+        updatePartialIndex(cells, i, lo, hi, stateOpacity)
+      end
+    end
+    if oldFirst ~= first and oldFirst >= first and oldFirst <= last then
+      updatePartialIndex(cells, oldFirst, lo, hi, stateOpacity)
+    end
+    if oldLast ~= last and oldLast >= first and oldLast <= last then
+      updatePartialIndex(cells, oldLast, lo, hi, stateOpacity)
+    end
+    updatePartialIndex(cells, first, lo, hi, stateOpacity)
+    if last ~= first then
+      updatePartialIndex(cells, last, lo, hi, stateOpacity)
+    end
+  end
+  frame.segmentFirst, frame.segmentLast = first, last
+  frame.segmentWhole = first and (last - first + 1) or 0
+end
+
+local function updatePointCells(widget, objects, normalized, stateOpacity)
+  local cells, frame = objects.faceCells, widget.frame
+  local axis = widget.layout.axis
+  if axis.prefixOrigin then
+    local active = frame.segmentActive or 0
+    while active < #cells and normalized >= cells[active + 1].position do
+      active = active + 1
+      setCellFraction(cells[active], 1, stateOpacity)
+    end
+    while active > 0 and normalized < cells[active].position do
+      setCellFraction(cells[active], 0, stateOpacity)
+      active = active - 1
+    end
+    frame.segmentActive = active
+    return
+  end
+  local active = 0
+  local lo, hi = G.axisOriginSpan(axis, normalized)
+  local hasSpan = hi > lo
+  for i = 1, #cells do
+    local position = cells[i].position
+    local on = hasSpan and position >= lo and position <= hi
+    if on then active = active + 1 end
+    setCellFraction(cells[i], on and 1 or 0, stateOpacity)
+  end
+  frame.segmentActive = active
+end
+
+local function updateWholeCells(widget, objects, normalized, stateOpacity)
+  local cells, frame = objects.faceCells, widget.frame
+  if widget.layout.axis.prefixOrigin then
+    local whole = (normalized >= 1) and #cells or floor(normalized * #cells)
+    local oldWhole = frame.segmentWhole or 0
+    if whole > oldWhole then
+      for i = oldWhole + 1, whole do
+        setCellFraction(cells[i], 1, stateOpacity)
+      end
+    elseif whole < oldWhole then
+      for i = oldWhole, whole + 1, -1 do
+        setCellFraction(cells[i], 0, stateOpacity)
+      end
+    end
+    frame.segmentWhole = whole
+    return
+  end
+  updatePointCells(widget, objects, normalized, stateOpacity)
+  frame.segmentWhole = frame.segmentActive
+end
+
+local function segmentedUpdate(widget, objects, state)
+  local cells, frame = objects.faceCells, widget.frame
+  local opacityChanged = frame.segmentOpacity ~= state.opacity
+  frame.segmentOpacity = state.opacity
+  if not state.visualValid then
+    for i = 1, #cells do
+      setCellFraction(cells[i], 0, state.opacity)
+    end
+    if objects.repaintAll or opacityChanged then
+      for i = 1, #cells do paintCell(cells[i], state.opacity) end
+    end
+    objects.repaintAll, objects.repaintActive = false, false
+    frame.segmentWhole, frame.segmentActive = 0, 0
+    if frame.headShown and objects.head then
+      frame.headShown = false
+      lvgl.hide(objects.head)
+    end
+    return
+  end
+
+  local normalized = state.smoothNormalized
+  if objects.activation == "partial" then
+    updatePartialCells(widget, objects, normalized, state.opacity)
+  elseif objects.activation == "points" then
+    updatePointCells(widget, objects, normalized, state.opacity)
+  else -- whole increasing steps
+    updateWholeCells(widget, objects, normalized, state.opacity)
+  end
+
+  if objects.repaintAll or opacityChanged then
+    for i = 1, #cells do paintCell(cells[i], state.opacity) end
+  elseif objects.repaintActive then
+    for i = 1, #cells do
+      if (cells[i].fraction or 0) > 0 then
+        paintCell(cells[i], state.opacity)
+      end
+    end
+  end
+  objects.repaintAll, objects.repaintActive = false, false
+
+  local axis = widget.layout.axis
+  local position = pointAt(axis, normalized)
+  if objects.head and position ~= frame.headPos then
+    frame.headPos, frame.headX = position, position
+    moveHead(objects, "head", axis, position)
+    frame.headShown = true
+  elseif objects.head and not frame.headShown then
+    frame.headShown = true
+    lvgl.show(objects.head)
+  end
+end
+
+local function segmentedVisible(objects, visible)
+  local fn = visible and lvgl.show or lvgl.hide
+  if objects.panel then fn(objects.panel) end
+  for i = 1, #objects.faceCells do
+    local cell = objects.faceCells[i]
+    if cell.parts then
+      for j = 1, #cell.parts do fn(cell.parts[j]) end
+    else
+      fn(cell.primary)
+    end
+  end
+  if objects.head then fn(objects.head) end
+end
+
+local function beginSegmented(widget, style, kind)
+  buildPanel(widget, style)
+  local ui = widget.ui
+  ui.faceKind = kind
+  ui.faceCells = {}
+  ui.faceCells.paintProps = {}
+  ui.faceRoleBands = roleBands(widget)
+  return widget.layout.axis, ui.faceCells,
+    ui.faceRoleBands
+end
+
+local function appendCell(cells, primary, parts, position, role, variant,
+                          fromPosition, toPosition)
+  local cell = {
+    primary = primary, parts = parts, position = position, role = role,
+    fraction = 0, baseOpacity = T.opacity.rail,
+    referenceColor = T.color.rail, activeColor = T.color.accent,
+    variant = variant, paintProps = cells.paintProps,
+    fromPosition = fromPosition, toPosition = toPosition,
+  }
+  cells[#cells + 1] = cell
+  return cell
+end
+
+local function blocksBuild(widget, _geometry, style)
+  local axis, cells = beginSegmented(widget, style, "blocks")
+  local gap = gapPixels(style)
+  local minCell = T.px(3)
+  local geometryCap = max(6, floor((axis.length + gap) / (minCell + gap)))
+  local count = budgetedCount(widget, style, 38, 1, 6, 24, geometryCap)
+  local radius = (style.ends == "round")
+    and min(T.px(3), floor(axis.crossLength / 3)) or 0
+  local variant = (radius > 0) and "soft" or "square"
+  for i = 1, count do
+    local x, y, w, h, t1, t2 = slotGeometry(axis, i, count, gap)
+    local rect = lvgl.rectangle{
+      x = x, y = y, w = w, h = h,
+      color = widget.barPalette.track, opacity = T.opacity.rail,
+      filled = 1, rounded = radius,
+    }
+    local position = (i - 0.5) / count
+    appendCell(cells, rect, nil, position, nil, variant, t1, t2)
+  end
+  widget.ui.fill = cells[1] and cells[1].primary or nil
+  widget.ui.activation = "partial"
+  return true
+end
+
+local function hexBuild(widget, _geometry, style)
+  local axis, cells = beginSegmented(widget, style, "hex")
+  local gap = gapPixels(style)
+  local tip = min(floor(axis.crossLength / 2), T.px(6))
+  local compactBlock = tip < T.px(2) or axis.crossLength < T.px(5)
+  local perCell = compactBlock and 1 or 3
+  local minimumWidth = compactBlock and T.px(3) or (tip * 2 + T.px(2))
+  local geometryCap = max(6, floor((axis.length + gap) / (minimumWidth + gap)))
+  local count = budgetedCount(widget, style, 40, perCell, 6, 10, geometryCap)
+  if compactBlock then
+    style.faceVariant = "blocks-compact"
+    addDowngrade(style, "hex-compact-blocks")
+  else
+    style.faceVariant = "true-hex"
+  end
+  for i = 1, count do
+    local x, y, w, h, t1, t2 = slotGeometry(axis, i, count, gap)
+    local position = (i - 0.5) / count
+    local primary = (axis.orientation == "vertical") and h or w
+    if compactBlock or primary < tip * 2 + 1 then
+      local rect = lvgl.rectangle{
+        x = x, y = y, w = w, h = h,
+        color = widget.barPalette.track, opacity = T.opacity.rail,
+        filled = 1, rounded = 0,
+      }
+      appendCell(cells, rect, nil, position, nil, "block", t1, t2)
+      style.faceVariant = "blocks-compact"
+    else
+      local localTip = min(tip, floor((primary - 1) / 2))
+      local center, first, second
+      if axis.orientation == "vertical" then
+        local centerY = y + localTip
+        local centerH = max(1, h - localTip * 2)
+        center = lvgl.rectangle{
+          x = x, y = centerY, w = w, h = centerH,
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+          filled = 1, rounded = 0,
+        }
+        local midX = x + floor(w / 2)
+        first = lvgl.triangle{
+          pts = { { x, centerY }, { midX, y }, { x + w, centerY } },
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+        }
+        local bottomY = centerY + centerH
+        second = lvgl.triangle{
+          pts = { { x, bottomY }, { x + w, bottomY }, { midX, y + h } },
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+        }
+      else
+        local centerX = x + localTip
+        local centerW = max(1, w - localTip * 2)
+        center = lvgl.rectangle{
+          x = centerX, y = y, w = centerW, h = h,
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+          filled = 1, rounded = 0,
+        }
+        local midY = y + floor(h / 2)
+        first = lvgl.triangle{
+          pts = { { centerX, y }, { centerX, y + h }, { x, midY } },
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+        }
+        local rightX = centerX + centerW
+        second = lvgl.triangle{
+          pts = { { rightX, y }, { x + w, midY }, { rightX, y + h } },
+          color = widget.barPalette.track, opacity = T.opacity.rail,
+        }
+      end
+      appendCell(cells, center, { center, first, second }, position, nil,
+                 "hex", t1, t2)
+    end
+  end
+  widget.ui.fill = cells[1] and cells[1].primary or nil
+  widget.ui.activation = "partial"
+  return true
+end
+
+local function thresholdTicks(widget, count)
+  local forced = {}
+  for i = 1, #widget.ranges do
+    local range = widget.ranges[i]
+    local position = G.normalize(range.to, widget.config.min, widget.config.max)
+    if position > 0 and position < 1 then
+      local index = floor(position * (count - 1) + 1.5)
+      index = max(2, min(count - 1, index))
+      forced[index] = { position = position, role = range.role }
+    end
+  end
+  return forced
+end
+
+local function ticksBuild(widget, _geometry, style)
+  local axis, cells = beginSegmented(widget, style, "ticks")
+  local geometryCap = max(8, floor(axis.length / T.px(4)) + 1)
+  local count = budgetedCount(widget, style, 40, 1, 8, 28, geometryCap)
+  local forced = thresholdTicks(widget, count)
+  local thickness = max(2, T.px(2))
+  for i = 1, count do
+    local info = forced[i]
+    local position = info and info.position or ((i - 1) / (count - 1))
+    local major = info ~= nil or i == 1 or i == count or ((i - 1) % 5 == 0)
+    local cross = major and axis.crossLength
+      or max(1, floor(axis.crossLength * 0.65))
+    local point = G.axisPoint(axis, position)
+    local x, y, w, h
+    if axis.orientation == "vertical" then
+      x, w = axis.x + axis.w - cross, cross
+      y = max(axis.y, min(axis.y + axis.h - thickness,
+                          point - floor(thickness / 2)))
+      h = thickness
+    else
+      x = max(axis.x, min(axis.x + axis.w - thickness,
+                          point - floor(thickness / 2)))
+      y, w, h = axis.y + axis.h - cross, thickness, cross
+    end
+    local rect = lvgl.rectangle{
+      x = x, y = y, w = w, h = h,
+      color = widget.barPalette.track, opacity = T.opacity.rail,
+      filled = 1, rounded = major and 1 or 0,
+    }
+    local half = 0.5 / count
+    local cell = appendCell(cells, rect, nil, position, nil,
+      major and "major" or "minor", max(0, position - half),
+      min(1, position + half))
+    cell.major, cell.centerX = major, point
+    cell.thresholdRole = info and info.role or nil
+  end
+  widget.ui.fill = cells[1] and cells[1].primary or nil
+  widget.ui.activation = "points"
+  return true
+end
+
+local function stepsBuild(widget, _geometry, style)
+  local axis, cells = beginSegmented(widget, style, "steps")
+  local gap = gapPixels(style)
+  local geometryCap = max(5, floor((axis.length + gap) / (T.px(4) + gap)))
+  local count = budgetedCount(widget, style, 32, 1, 5, 10, geometryCap)
+  -- The staircase rises to the full cross-height, but its FIRST steps have to
+  -- stay readable: interpolating from 1 px left a 2 px active green beside a
+  -- 15 px inactive track - the data channel rendered thinner than the thing it
+  -- is drawn over. Start the ramp at a floor instead. The floor yields to the
+  -- staircase itself when the rail is too shallow to give every step its own
+  -- pixel, so the shape never stalls into two equal steps.
+  local rise = max(1, count - 1)
+  local ceiling = max(1, axis.crossLength)
+  -- The floor wins over strict monotonicity. A rail with fewer pixels than
+  -- steps cannot give each one its own height, and the old ramp resolved that
+  -- by starting at 1 px: on a real 800x480 radio the first active steps came
+  -- out 2 px of green beside 15 px of inactive track, so the data channel was
+  -- the faintest thing in the widget. Repeating a height at the bottom is a
+  -- far smaller lie than drawing the reading as a hairline - the staircase
+  -- still rises, it just starts from something you can see.
+  local floorCross = min(max(T.px(3), 1), ceiling)
+  for i = 1, count do
+    local x, y, w, h, t1, t2 = slotGeometry(axis, i, count, gap)
+    local cross = floorCross + floor((ceiling - floorCross) * (i - 1) / rise)
+    if axis.orientation == "vertical" then
+      x, w = axis.x + floor((axis.w - cross) / 2), cross
+    else
+      y, h = axis.y + axis.h - cross, cross
+    end
+    local position = (i - 0.5) / count
+    local rect = lvgl.rectangle{
+      x = x, y = y, w = w, h = h,
+      color = widget.barPalette.track, opacity = T.opacity.rail,
+      filled = 1, rounded = min(T.px(2), floor(w / 3)),
+    }
+    appendCell(cells, rect, nil, position, nil, "step", t1, t2)
+  end
+  widget.ui.fill = cells[1] and cells[1].primary or nil
+  widget.ui.activation = "steps"
+  return true
+end
+
+-- ---------------------------------------------------------- centred rail --
+
+local function dualSupports(_profile, config)
+  return (not config or config.direction == nil
+      or config.direction == "horizontal" or config.direction == "vertical")
+    and (not config or config.origin == nil or config.origin == "zero")
+end
+
+local function dualBuild(widget, _geometry, style)
+  buildPanel(widget, style)
+  local L, ui, palette = widget.layout, widget.ui, widget.barPalette
+  local axis, active = L.axis, L.activeAxis or L.axis
+  local radius = (style.ends == "round") and floor(axis.crossLength / 2) or 0
+  ui.faceKind = "dual-rail"
+  ui.dualTracks = {}
+  for i = 1, 2 do
+    local fromT, toT = (i == 1) and 0 or axis.originT,
+      (i == 1) and axis.originT or 1
+    local x, y, w, h = G.axisSpan(axis, fromT, toT)
+    -- Both halves are TRACK, exactly like every other face's inactive body.
+    -- They used to take palette.critical / palette.normal, so a stick pushed
+    -- to +65 % still showed a full-length saturated red bar on the negative
+    -- half - and under contrast assist that rail reached 59 % opacity, at
+    -- which point it is indistinguishable from a filled negative reading.
+    -- The sign is already carried by which side of the zero notch the fill
+    -- grows from; it does not need a second, contradictory channel.
+    local track = lvgl.rectangle{
+      x = x, y = y, w = max(1, w), h = max(1, h),
+      color = palette.track,
+      opacity = T.opacity.rail, filled = 1, rounded = radius,
+    }
+    ui.dualTracks[i] = track
+  end
+  local x, y, w, h = G.axisSpan(active, active.originT, active.originT)
+  ui.fill = lvgl.rectangle{
+    x = x, y = y, w = max(1, w), h = max(1, h),
+    color = palette.normal, filled = 1,
+    rounded = (style.ends == "round") and floor(active.crossLength / 2) or 0,
+  }
+  lvgl.hide(ui.fill)
+  return true
+end
+
+local function dualPalette(widget, objects, palette, state)
+  if objects.panel and state.paletteChanged then
+    R.setProp(widget, objects.panel, "color", palette.panel)
+  end
+  local assisted = palette.assist == "needed" or palette.assist == "strong"
+  local trackOpacity = (palette.assist == "strong") and T.opacity.railBand
+    or assisted and min(T.opacity.full, T.opacity.rail + 60) or T.opacity.rail
+  for i = 1, #objects.dualTracks do
+    local track = objects.dualTracks[i]
+    R.setProp(widget, track, "color", palette.track)
+    R.setProp(widget, track, "opacity", trackOpacity)
+  end
+  local negative = state.smoothValue ~= nil and state.smoothValue < 0
+  local fill = negative and palette.critical or palette.normal
+  R.setProp(widget, objects.fill, "color", fill)
+  R.setProp(widget, objects.fill, "opacity", state.opacity)
+  R.setProp(widget, objects.head, "color", T.labelOn(fill, palette))
+  R.setProp(widget, objects.head, "opacity", state.opacity)
+  local thickness = widget.layout.markThickness
+    + ((palette.assist == "strong") and T.px(2)
+       or assisted and T.px(1) or 0)
+    + (((state.headBoost or 0) > 0) and T.px(state.headBoost) or 0)
+  if objects.headKind == "line" then
+    R.setProp(widget, objects.head, "thickness", thickness)
+  end
+end
+
+local function dualUpdate(widget, objects, state)
+  local negative = state.smoothValue ~= nil and state.smoothValue < 0
+  if negative ~= widget.frame.dualNegative then
+    widget.frame.dualNegative = negative
+    local palette = widget.barPalette
+    local fill = negative and palette.critical or palette.normal
+    R.setProp(widget, objects.fill, "color", fill)
+    R.setProp(widget, objects.head, "color", T.labelOn(fill, palette))
+  end
+  continuousUpdate(widget, objects, state)
+end
+
+local function dualVisible(objects, visible)
+  local fn = visible and lvgl.show or lvgl.hide
+  if objects.panel then fn(objects.panel) end
+  for i = 1, #objects.dualTracks do fn(objects.dualTracks[i]) end
+  fn(objects.fill)
+  if objects.head then fn(objects.head) end
+end
+
+local function descriptor(name, targetLow, targetHigh, hardCeiling, estimate)
+  return {
+    name = name,
+    implemented = false,
+    targetObjects = { targetLow, targetHigh },
+    hardCeiling = hardCeiling,
+    supports = unavailableSupports,
+    estimateObjects = estimate,
+    build = unavailableBuild,
+    buildOverlay = unavailableBuild,
+    update = unavailableUpdate,
+    applyPalette = unavailablePalette,
+    setVisible = unavailableVisible,
+    ownsAlerts = false,
+  }
+end
+
+local REGISTRY = {
+  continuous = descriptor("continuous", 12, 38, 38, continuousEstimate),
+  blocks = descriptor("blocks", 16, 32, 38,
+    function(_profile, config) return min(config.segments or 10, 24) + 12 end),
+  hex = descriptor("hex", 22, 35, 40,
+    function(_profile, config) return min(config.segments or 8, 10) * 3 + 10 end),
+  ticks = descriptor("ticks", 18, 34, 40,
+    function(_profile, config) return min(config.segments or 20, 28) + 12 end),
+  steps = descriptor("steps", 12, 24, 32,
+    function(_profile, config) return min(config.segments or 8, 10) + 12 end),
+  ["dual-rail"] = descriptor("dual-rail", 16, 28, 36,
+    function() return 18 end),
+}
+
+local continuous = REGISTRY.continuous
+continuous.variantCeilings = { solid = 24, gradient = 38 }
+continuous.implemented = true
+continuous.supports = continuousSupports
+continuous.build = continuousBuild
+continuous.buildOverlay = continuousBuildOverlay
+continuous.update = continuousUpdate
+continuous.applyPalette = continuousPalette
+continuous.setVisible = continuousVisible
+
+local function installSegmented(face, build)
+  face.implemented = true
+  face.supports = segmentedSupports
+  face.build = build
+  face.buildOverlay = segmentedBuildOverlay
+  face.update = segmentedUpdate
+  face.applyPalette = segmentedPalette
+  face.setVisible = segmentedVisible
+end
+
+installSegmented(REGISTRY.blocks, blocksBuild)
+installSegmented(REGISTRY.hex, hexBuild)
+installSegmented(REGISTRY.ticks, ticksBuild)
+installSegmented(REGISTRY.steps, stepsBuild)
+
+local dual = REGISTRY["dual-rail"]
+dual.implemented = true
+dual.supports = dualSupports
+dual.build = dualBuild
+dual.buildOverlay = continuousBuildOverlay
+dual.update = dualUpdate
+dual.applyPalette = dualPalette
+dual.setVisible = dualVisible
+
+M.REGISTRY = REGISTRY
+M.ORDER = { "continuous", "blocks", "hex", "ticks", "steps", "dual-rail" }
+
+-- Selecting a later-phase face during this milestone is safe and
+-- explicit: the requested face remains in barVisual/signatures, while the
+-- retained Continuous adapter draws the production fallback.
+function M.select(name, profile, config)
+  local requested = REGISTRY[name]
+  if requested and requested.supports(profile, config) then
+    return requested, nil
+  end
+  return continuous, "face-phase-pending:" .. tostring(name or "unknown")
+end
+
+-- Allocate the shared face input once at build. Ordinary refresh only edits
+-- scalar fields and the existing threshold array.
+function M.buildRenderState(widget)
+  local state = {
+    valid = false, availability = "unset", state = "muted",
+    visualValid = false,
+    rawValue = nil, smoothValue = nil, rawNormalized = 0,
+    smoothNormalized = 0, minNormalized = nil, maxNormalized = nil,
+    colorKey = "muted", visualColor = nil,
+    rawOpacity = T.opacity.muted, opacity = T.opacity.muted,
+    pulseMode = "off", motionActive = false, motionPaused = false,
+    settleEnabled = false, settleIndex = nil, settleLevel = 0, headBoost = 0,
+    thresholds = {},
+  }
+  for i = 1, #widget.ranges do
+    local range = widget.ranges[i]
+    state.thresholds[i] = {
+      role = range.role,
+      fromPosition = G.normalize(range.from, widget.config.min,
+                                 widget.config.max),
+      toPosition = G.normalize(range.to, widget.config.min, widget.config.max),
+      position = G.normalize(range.to, widget.config.min, widget.config.max),
+    }
+  end
+  widget.barRenderState = state
+  return state
+end
+
+function M.updateRenderState(widget)
+  local state = widget.barRenderState
+  local data, cfg, frame = widget.data, widget.config, widget.frame
+  state.availability = data.availability
+  state.state = R.stateKey(widget)
+  state.colorKey = R.colorKey(widget)
+  state.rawOpacity = (state.colorKey == "muted") and T.opacity.muted
+                     or T.opacity.full
+  state.opacity = state.rawOpacity
+  state.rawValue = data.displayValue
+  state.valid = data.availability == "valid" and data.displayValue ~= nil
+  state.visualValid = state.valid
+  if not state.valid then
+    widget.smooth.value = nil
+    state.smoothValue = nil
+    state.rawNormalized, state.smoothNormalized = 0, 0
+  else
+    if frame.prevAvail ~= "valid" then widget.smooth.value = nil end
+    state.smoothValue = widget.mods.smoothing.step(widget, data.displayValue)
+    state.rawNormalized = G.normalize(data.displayValue, cfg.min, cfg.max)
+    state.smoothNormalized = G.normalize(state.smoothValue, cfg.min, cfg.max)
+  end
+  local history = widget.history
+  state.minNormalized = history.min
+    and G.normalize(history.min, cfg.min, cfg.max) or nil
+  state.maxNormalized = history.max
+    and G.normalize(history.max, cfg.min, cfg.max) or nil
+  return state
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_layout.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_layout.lua
@@ -1,0 +1,456 @@
+---- Gauge Core - bar-only responsive layout ------------------------------
+
+local M = {}
+local floor, min, max = math.floor, math.min, math.max
+local C, T, G, F
+local clamp, box, chipOverhang, placeValue
+
+function M.setup(common, theme, geometry, format)
+  C, T, G, F = common, theme, geometry, format
+  clamp, box = C.clamp, C.box
+  chipOverhang, placeValue = C.chipOverhang, C.placeValue
+end
+
+-- ------------------------------------------------------------------- bar --
+
+local function barLayout(widget, cfg, L, w, h)
+  -- The layout stacks value / bar / state row with `pad` between and around
+  -- them: three gaps, 12 px at the normal step. In a 44 px zone that is more
+  -- than a quarter of the height, competing directly with the value font
+  -- floor (P1-4) and the state row (P1-2) - and it was exactly the 2 px the
+  -- old budget had to under-reserve to keep both, which is what pushed the
+  -- pill out of the zone. Short bars (the same breakpoint that drops the
+  -- name) buy the room back from the padding instead, honestly.
+  local compactPad = T.px(T.space.xs)
+  local pad = (h < T.px(46)) and compactPad or T.px(T.space.sm)
+  L.showUnit = true
+  L.showValue = true
+  L.showName = h >= T.px(46)
+  -- the row is reserved whatever ShowChip says: see the dial branch (F9)
+  L.showState = w >= T.px(120)
+  L.showMarkers = (cfg.showMinMax or 1) > 1
+  -- Slot 6 is one of the SHARED options, so its third choice has to mean the
+  -- same thing here as it does on the dial. It used to be hard-wired false:
+  -- "Markers + text" was pixel-identical to "Markers" on every bar, at every
+  -- size. Placement is decided after placeValue, against the room the value
+  -- row actually leaves.
+  L.showMinMaxText = (cfg.showMinMax or 1) > 2
+  L.showScale = false
+  L.showGhost = true
+  L.showNeedle = false
+
+  L.nameFont = T.FONTS.XS
+  L.stateFont = T.FONTS.XS
+  L.minMaxFont = T.FONTS.XXS
+  -- A real fullscreen landscape instrument needs a composed visual block,
+  -- not a value centred in all remaining height with a rail pinned to the
+  -- bottom. This flag changes pixels only; the stored option contract and all
+  -- compact degradation rules remain untouched.
+  local fullscreen = w >= T.px(400) and h >= T.px(240)
+  L.fullscreenBar = fullscreen
+  if fullscreen then L.minMaxFont = T.FONTS.XS end
+  local nameH = T.fontHeight(L.nameFont)
+  local stateH = T.fontHeight(L.stateFont)
+  -- the smallest font the value can use: the value region must never drop
+  -- under this, or the auto-fit would overflow the box (AUDIT.md P1-4)
+  local minText = T.fontHeight(T.FONTS.XXS)
+
+  -- The min/max marker and the peak-hold ghost stick out this far above AND
+  -- below the bar, so they read as ticks against it rather than as part of
+  -- the fill. It is LAYOUT data because it is part of the bar's real
+  -- footprint and the budget below has to reserve it: bar.lua reads it back
+  -- instead of restating px(2)/px(4), which is what kept the two in sync
+  -- once the pill taught the same lesson.
+  L.markOverhang = T.px(2)
+
+  -- Width of the chipEdge outline drawn around the state pill, on EACH side.
+  -- Both renderers must inset by this and grow by twice it - never by
+  -- T.px(2), which is not 2 * T.px(1) at every LCD_SCALE (see chipOverhang).
+  L.chipOutline = T.px(1)
+
+  -- The row below the bar carries the state text (right) and, when there is
+  -- height for it, the name (left). Its height is the STATE font's, never
+  -- the name's: sizing it from nameH meant the short-bar paths zeroed nameH
+  -- and collapsed STALE/NO LINK/WARN/CRIT out of exactly the zones where
+  -- they matter most (AUDIT.md P1-2). Both fonts are XS here, so the two
+  -- readings coincide today - naming the state font keeps it that way if
+  -- either font is ever re-tuned.
+  --
+  -- VERTICAL BUDGET. The zone has to hold, top to bottom: the value area,
+  -- the bar, and the state/name row - and the state PILL is taller than its
+  -- text and centred on it (review P-B), so the row must also reserve what
+  -- the pill hangs below that text (chipOverhang, outline included).
+  --
+  -- When it does not all fit, relax in this order, giving up the least
+  -- important thing left each time:
+  --
+  --   1. full pill, preferred bar height     (the intended look)
+  --   2. full pill, bar trimmed to its floor
+  --   3. minimal pill (stateH + 2)
+  --   4. bare pill (stateH + 0): no vertical padding, outline only
+  --   5. no state row at all
+  --
+  -- Rungs 1-4 all keep WARN / CRIT / NO LINK on screen, which is what P1-2
+  -- guarantees; rung 4 exists precisely so that a 44 px bar reaches it
+  -- instead of falling to rung 5. Every rung sizes the row from the pill it
+  -- actually paints, which is what keeps the pill inside the zone: the old
+  -- nested version reserved floor(chipExtra / 2) - forgetting the 1 px
+  -- outline - and reserved nothing at all on the minimal-pill rung, so the
+  -- pill left the bottom of EVERY bar zone by 1 px, and a short one by 2.
+  local chipExtra, rowH, barH, textH
+
+  -- One rung: the tallest bar this pill size allows, else the bar trimmed to
+  -- its floor. Returns true when the value area still fits.
+  local function fits(extra)
+    chipExtra = extra
+    rowH = (L.showState or L.showName)
+      and (stateH + chipOverhang(L.showState, extra, L.chipOutline)) or 0
+    -- What has to fit UNDER the bar. With no row down there, the bottom pad
+    -- is all that separates the bar from the zone edge, and the markers
+    -- already stick markOverhang px past it - so the marker, not the row,
+    -- sets the floor. A real row is always taller than the overhang, so this
+    -- only ever bites on the row-less short bar it was written for.
+    local below = max(rowH, L.markOverhang)
+    barH = clamp(floor(h * 0.34), T.px(8), T.px(26))
+    textH = h - barH - below - pad * 3
+    if textH >= minText then return true end
+    barH = max(h - minText - below - pad * 3, T.px(8))
+    textH = h - barH - below - pad * 3
+    return textH >= minText
+  end
+
+  if not L.showState then
+    fits(0)
+  else
+    local stateFits = fits(T.px(6)) or fits(T.px(2)) or fits(0)
+    -- The old height breakpoint changed TWO variables at h=px(46): it added
+    -- the name and switched xs -> sm padding. With the real EdgeTX font
+    -- heights, a 46 px bar therefore lost its safety row after a 44 px bar
+    -- had shown it, then regained it later. Padding is another degradation
+    -- rung: if the preferred spacing fails, retry the exact same pill ladder
+    -- with compact spacing before removing WARN/CRIT.
+    if not stateFits and pad > compactPad then
+      pad = compactPad
+      stateFits = fits(T.px(6)) or fits(T.px(2)) or fits(0)
+    end
+    if not stateFits then
+      L.showState = false               -- final rung: last resort
+      fits(0)
+    end
+  end
+  -- A zone too short for even the smallest value font keeps the font's
+  -- height anyway; the value box is what the auto-fit needs (AUDIT.md P1-4).
+  --
+  -- But raising textH back up does not create pixels. The bar was sized from
+  -- the budget that did NOT fit, so unless it gives the room back the track
+  -- is drawn past the bottom edge of the zone - measured at 200x20: the bar
+  -- ended 3 px outside, taking the min/max marks (markOverhang) with it.
+  -- LVGL clips it to the parent, so this is a silently truncated instrument
+  -- rather than a crash, which is precisely why it survived this long.
+  -- The bar is the element that degrades most gracefully here: a 2 px bar
+  -- still reads as a bar, a bar outside the widget reads as nothing.
+  if textH < minText then
+    textH = minText
+    barH = max(h - textH - max(rowH, L.markOverhang) - pad * 3, T.px(2))
+  end
+
+  local groupTop = pad
+  if fullscreen then
+    barH = clamp(floor(h * 0.09), T.px(24), T.px(42))
+    textH = clamp(floor(h * 0.26), T.fontHeight(T.FONTS.XL), T.px(124))
+    local below = max(rowH, L.markOverhang)
+    local groupH = textH + barH + below + pad * 3
+    groupTop = max(pad, floor((h - groupH) / 2))
+  end
+
+  local valueRegion = box(pad, groupTop, w - pad * 2, textH)
+  placeValue(L, valueRegion, F.widestSample(widget),
+             L.showUnit and widget.unitText or "",
+             (h < T.px(60)) and T.FONTS.M or nil)
+
+  -- "min N" / "max N" ride the ENDS of the value row rather than claiming a
+  -- row of their own: the five-rung vertical ladder above has already spent
+  -- every pixel this zone has, and a horizontal bar leaves that row's two
+  -- margins empty around a centred value. Reserved against the configured
+  -- endpoints - the longest legitimate captions for this scale - exactly as
+  -- the dial does, and dropped back to the marks when either margin is too
+  -- narrow, so a live extreme can never wrap or collide with the value.
+  if L.showMinMaxText then
+    local minMaxH = T.fontHeight(L.minMaxFont)
+    local need = max(
+      T.textWidth("min " .. F.display(widget, cfg.min), L.minMaxFont),
+      T.textWidth("max " .. F.display(widget, cfg.max), L.minMaxFont))
+    local groupLeft = L.valueBox.x
+    local groupRight = (L.unitBox and L.showUnit)
+      and (L.unitBox.x + L.unitBox.w) or (L.valueBox.x + L.valueBox.w)
+    local leftRoom = groupLeft - pad * 2
+    local rightRoom = (w - pad) - groupRight - pad
+    local baseline = L.valueBox.y + L.valueBox.h - minMaxH
+    if need > 0 and leftRoom >= need and rightRoom >= need
+       and baseline >= pad then
+      L.minTextBox = box(pad, baseline, leftRoom, minMaxH)
+      L.maxTextBox = box(groupRight + pad, baseline, rightRoom, minMaxH)
+    else
+      L.showMinMaxText = false
+    end
+  end
+
+  L.bar = box(pad, groupTop + textH + pad, w - pad * 2, barH)
+  -- Below roughly 24 px of zone height nothing fits honestly any more: textH
+  -- has already been floored at the smallest font in the ramp (P1-4) and barH
+  -- at px(2), and the two plus the padding still exceed the zone. Slide the
+  -- bar up rather than let it - and the min/max marks that overhang it by
+  -- markOverhang - be drawn past the bottom edge. The value then overlaps the
+  -- bar, which is the honest picture at that size; painting outside the
+  -- widget is not, and LVGL would clip it away unseen.
+  local barLimit = h - L.markOverhang
+  if L.bar.y + L.bar.h > barLimit then
+    L.bar.y = max(barLimit - L.bar.h, L.markOverhang)
+    if L.bar.y + L.bar.h > h then L.bar.h = max(h - L.bar.y, 1) end
+    barH = L.bar.h
+  end
+  -- Keep the complete, containment-corrected footprint. Phase 2 can make the
+  -- visible rail thin or thick inside this slot without rerunning (or
+  -- weakening) the five-rung short-zone budget above.
+  L.barSlot = box(L.bar.x, L.bar.y, L.bar.w, L.bar.h)
+  L.barRadius = floor(barH / 2)
+  L.nameBox = box(pad, L.bar.y + barH + pad, floor((w - pad * 2) / 2), nameH)
+  L.stateBox = box(pad + floor((w - pad * 2) / 2), L.bar.y + barH + pad,
+                   floor((w - pad * 2) / 2), stateH)
+  L.nameAlign = LEFT
+  L.stateAlign = RIGHT
+  L.textAlign = LEFT
+  -- same pill as the dial (review P-B), sized to what the zone could reserve
+  L.chipPad = T.px(7)
+  L.chipHeight = stateH + chipExtra
+  -- see the dial branch: chipOff must come from the layout, or a no-op
+  -- update() loses it and the next chip render crashes (Tanda 6 F-1)
+  L.chipOff = floor((L.chipHeight - stateH) / 2)
+  L.markThickness = max(1, T.px(2))
+end
+
+-- Resolve the visible Continuous-rail body inside the footprint barLayout
+-- already proved fits. Appearance is resolved after M.calculate(), because
+-- the immutable bar-style resolver owns preset/override precedence while the
+-- layout owns pixels. Keeping that seam explicit prevents a BarSize edit from
+-- bypassing the short-bar degradation ladder.
+function M.applyBarVisual(L, visual, cfg)
+  if not L or L.style ~= "bar" or not visual then return L end
+  local slot = L.barSlot or L.bar
+  local vertical = visual.direction == "vertical"
+  L.barDirection = vertical and "vertical" or "horizontal"
+  L.valuePosition = visual.valuePos or "auto"
+  L.labelPosition = visual.labelPos or "auto"
+  L.showValue = L.valuePosition ~= "off"
+  if not L.showValue then L.showUnit = false end
+  if L.labelPosition == "off" then L.showName = false end
+
+  if vertical then
+    -- Reclaim the tall zone: barLayout has already selected safe fonts and
+    -- badge dimensions, but its provisional horizontal rail would consume
+    -- only ~26 px. Keep the information hierarchy above/below and turn the
+    -- middle into a genuine vertical instrument.
+    local pad = max(1, slot.x)
+    local top = pad
+    local valueH = L.showValue and L.valueBox.h or 0
+    local nameH = L.showName and L.nameBox.h or 0
+    local topRows = 0
+    if L.showValue and (L.valuePosition == "auto"
+       or L.valuePosition == "above") then
+      topRows = topRows + valueH + pad
+    end
+    if L.showName and L.labelPosition == "above" then
+      topRows = topRows + nameH + pad
+    end
+    top = top + topRows
+
+    local belowName = L.showName and (L.labelPosition == "auto"
+      or L.labelPosition == "below")
+    local bottomRows = belowName and nameH or 0
+    if L.showState then
+      local stateFoot = L.chipHeight - L.chipOff + L.chipOutline
+      if bottomRows > 0 then bottomRows = bottomRows + pad end
+      bottomRows = bottomRows + stateFoot
+    end
+    local bottom = L.h - pad - ((bottomRows > 0) and (bottomRows + pad) or 0)
+    if bottom <= top then
+      -- A pathological tiny/tall zone keeps containment and makes the value
+      -- an overlay before sacrificing the data axis.
+      top = pad
+      L.valuePosition = L.showValue and "inside" or L.valuePosition
+      bottom = max(top + 1, L.h - pad
+        - ((bottomRows > 0) and (bottomRows + pad) or 0))
+    end
+    slot = box(pad, top, max(1, L.w - pad * 2), max(1, bottom - top))
+    L.barSlot = slot
+
+    -- "Inside" on a tall instrument means inside the instrument footprint,
+    -- not printed through its data rail. Reserve a compact information lane
+    -- beside the rail whenever the value/name is authored Inside or End. This
+    -- keeps ticks, threshold marks and the moving head readable while giving
+    -- the text a stable high-contrast canvas in both light and dark themes.
+    local sideValue = L.showValue
+      and (L.valuePosition == "inside" or L.valuePosition == "end")
+    local sideLabel = L.showName and L.labelPosition == "inside"
+    if (sideValue or sideLabel) and slot.w >= T.px(36) then
+      local gap = max(pad, T.px(3))
+      local railW = max(T.px(12), floor((slot.w - gap) * 0.38))
+      railW = min(railW, max(1, slot.w - gap - T.px(18)))
+      L.barRailSlot = box(slot.x, slot.y, railW, slot.h)
+      local textX = slot.x + railW + gap
+      local textW = max(1, slot.x + slot.w - textX)
+      if sideValue then
+        L.valueBox.x, L.valueBox.w = textX, textW
+        L.valueAlign = LEFT
+      end
+      if sideLabel then
+        L.nameBox.x, L.nameBox.w = textX, textW
+        L.nameAlign = LEFT
+      end
+    end
+
+    if L.showValue then
+      if L.valuePosition == "inside" then
+        L.valueBox.y = top + floor((slot.h - L.valueBox.h) / 2)
+      elseif L.valuePosition == "end" then
+        L.valueBox.y = top
+      else
+        L.valueBox.y = pad
+      end
+    end
+    if L.showName then
+      if L.labelPosition == "above" then
+        L.nameBox.x, L.nameBox.y, L.nameBox.w = pad,
+          pad + ((L.showValue and (L.valuePosition == "above"
+            or L.valuePosition == "auto"))
+            and (valueH + pad) or 0), L.w - pad * 2
+        L.nameAlign = LEFT
+      elseif L.labelPosition == "inside" then
+        if not L.barRailSlot then
+          L.nameBox.x, L.nameBox.w, L.nameAlign = pad, L.w - pad * 2, CENTER
+        end
+        L.nameBox.y = max(top, bottom - nameH - pad)
+      else
+        L.nameBox.x, L.nameBox.y, L.nameBox.w = pad, bottom + pad,
+          L.w - pad * 2
+        L.nameAlign = CENTER
+      end
+    end
+    if L.showState then
+      L.stateBox.x, L.stateBox.y = pad + floor((L.w - pad * 2) / 2),
+        bottom + pad + (belowName and (nameH + pad) or 0)
+      L.stateBox.w = floor((L.w - pad * 2) / 2)
+    end
+  else
+    -- Horizontal placement variants preserve the proven short-bar footprint;
+    -- they only move information within its reserved regions. This keeps the
+    -- state row and marker overhang guarantees intact at 44 px heights.
+    local pad = max(1, slot.x)
+    if L.showValue and L.valuePosition == "inside" then
+      L.valueBox.x, L.valueBox.y, L.valueBox.w = pad,
+        slot.y + floor((slot.h - L.valueBox.h) / 2), L.w - pad * 2
+      L.valueAlign = CENTER
+    elseif L.showValue and L.valuePosition == "end" then
+      L.valueBox.x, L.valueBox.w = floor(L.w * 0.5),
+        max(1, L.w - floor(L.w * 0.5) - pad)
+      L.valueAlign = RIGHT
+    end
+    if L.showName and L.labelPosition == "above" then
+      L.nameBox.x, L.nameBox.y, L.nameBox.w = pad, pad,
+        max(1, floor((L.w - pad * 2) / 2))
+      L.nameAlign = LEFT
+    elseif L.showName and L.labelPosition == "inside" then
+      L.nameBox.x, L.nameBox.y, L.nameBox.w = pad,
+        slot.y + max(0, slot.h - L.nameBox.h), L.w - pad * 2
+      L.nameAlign = CENTER
+    end
+  end
+
+  -- placeValue() authored the unit against the original value baseline. Any
+  -- presentation variant that moves the value row must move that baseline as
+  -- one semantic group; anchorUnit() will handle the live horizontal edge.
+  if L.showValue and L.showUnit and L.unitBox then
+    L.unitBox.y = L.valueBox.y + L.valueBox.h - L.unitBox.h - T.px(1)
+  end
+
+  local railSlot = L.barRailSlot or slot
+  local maximum = max(1, vertical and railSlot.w or railSlot.h)
+  local family = visual.profile and visual.profile.family or "standard"
+  local large = family == "large"
+  local wanted
+  if visual.thickness == "thin" then
+    wanted = T.px(large and 5 or 4)
+  elseif visual.thickness == "thick" then
+    wanted = T.px(large and 22 or 16)
+  elseif visual.thickness == "maximum" then
+    wanted = maximum
+  else
+    wanted = T.px((large and L.fullscreenBar) and 20 or large and 14 or 10)
+  end
+  wanted = clamp(wanted, min(maximum, T.px(2)), maximum)
+
+  local outerX = vertical and (railSlot.x + floor((railSlot.w - wanted) / 2))
+    or railSlot.x
+  local outerY = vertical and railSlot.y
+    or (railSlot.y + floor((railSlot.h - wanted) / 2))
+  L.barOuter = vertical and box(outerX, outerY, wanted, railSlot.h)
+    or box(outerX, outerY, railSlot.w, wanted)
+
+  -- A retained outline around the track supplies a real casing. The outline
+  -- must not be filled: it can become fully opaque under contrast assist and
+  -- would otherwise defeat the inactive track's reduced opacity (W-03). The
+  -- inset is surrendered on extremely small rails so the data channel never
+  -- collapses to zero pixels.
+  local primaryLength = vertical and slot.h or slot.w
+  local edge = (wanted >= T.px(5) and primaryLength >= T.px(12))
+    and T.px(1) or 0
+  local innerW = max(1, L.barOuter.w - edge * 2)
+  local innerH = max(1, L.barOuter.h - edge * 2)
+  L.bar = box(L.barOuter.x + edge, L.barOuter.y + edge, innerW, innerH)
+  L.barEdge = edge
+  L.barThickness = visual.thickness
+  L.barEnds = visual.ends
+  L.barRadius = (visual.ends == "round")
+    and floor((vertical and innerW or innerH) / 2) or 0
+  L.barOuterRadius = (visual.ends == "round") and floor(wanted / 2) or 0
+  L.barChamfer = (visual.ends == "chamfer")
+    and min(floor((vertical and innerW or innerH) / 2), T.px(6)) or 0
+  local axisInset = L.barChamfer
+  if vertical then
+    L.barAxis = box(L.bar.x, L.bar.y + axisInset, L.bar.w,
+                    max(1, L.bar.h - axisInset * 2))
+  else
+    L.barAxis = box(L.bar.x + axisInset, L.bar.y,
+                    max(1, L.bar.w - axisInset * 2), L.bar.h)
+  end
+  L.activeBar = box(L.barAxis.x, L.barAxis.y, L.barAxis.w, L.barAxis.h)
+  if cfg and (cfg.colorMode == 3 or cfg.colorMode == 5)
+     and (vertical and L.barAxis.w or L.barAxis.h) >= T.px(5) then
+    local cross = vertical and L.barAxis.w or L.barAxis.h
+    local rail = max(1, min(T.px(3), floor(cross * 0.3)))
+    if vertical then
+      L.activeBar.w = max(1, L.barAxis.w - rail - T.px(1))
+    else
+      L.activeBar.h = max(1, L.barAxis.h - rail - T.px(1))
+    end
+  end
+  L.axis = G.makeAxis(L.barAxis, L.barDirection, cfg.min, cfg.max,
+                      visual.origin)
+  L.activeAxis = G.makeAxis(L.activeBar, L.barDirection, cfg.min, cfg.max,
+                            visual.origin)
+  return L
+end
+
+
+function M.calculate(widget, cfg, L)
+  local w, h = widget.zone.w, widget.zone.h
+  if not L then
+    local mode, orientation = C.classify(w, h)
+    L = { mode = mode, orientation = orientation, w = w, h = h }
+  end
+  L.style = "bar"
+  barLayout(widget, cfg, L, w, h)
+  return L
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_style.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/bar_style.lua
@@ -1,0 +1,602 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - bar personalization resolver                              #
+---- #                                                                       #
+---- # Stored options are inputs, never working state. This module resolves  #
+---- # preset -> explicit override -> responsive compact variant into a      #
+---- # per-widget visual contract and a runtime theme-aware palette.         #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local T, SENSOR_PRESETS
+local min, max = math.min, math.max
+
+function M.setup(theme, presets)
+  T, SENSOR_PRESETS = theme, presets
+end
+
+-- Appearance presets are deliberately data, not branches scattered through
+-- renderers. `compact` documents the predictable small-zone downgrade.
+local PRESETS = {
+  [1] = {
+    key = "auto-source", label = "Auto Source", sourceAware = true,
+    face = "continuous", palette = "classic", direction = "auto",
+    origin = "scale-low", thickness = "medium", ends = "round",
+    segments = 10, gap = "normal", surface = "transparent",
+    contrast = "auto", motion = "refined",
+    compact = "source face with reduced detail",
+  },
+  [2] = {
+    key = "classic-rail", label = "Classic Rail",
+    face = "continuous", palette = "classic", direction = "auto",
+    origin = "scale-low", thickness = "medium", ends = "round",
+    segments = 10, gap = "normal", surface = "transparent",
+    contrast = "auto", motion = "refined",
+    compact = "continuous medium rail",
+  },
+  [3] = {
+    key = "theme-clean", label = "Theme Clean",
+    face = "continuous", palette = "theme", direction = "auto",
+    origin = "scale-low", thickness = "thin", ends = "round",
+    segments = 10, gap = "tight", surface = "theme-panel",
+    contrast = "auto", motion = "essential",
+    compact = "thin continuous line without panel",
+  },
+  [4] = {
+    key = "hex-telemetry", label = "Hex Telemetry",
+    face = "hex", palette = "classic", direction = "auto",
+    origin = "scale-low", thickness = "medium", ends = "chamfer",
+    segments = 8, gap = "normal", surface = "theme-panel",
+    contrast = "auto", motion = "refined",
+    compact = "six chamfered cells",
+  },
+  [5] = {
+    key = "status-blocks", label = "Status Blocks",
+    face = "blocks", palette = "classic", direction = "auto",
+    origin = "scale-low", thickness = "medium", ends = "square",
+    segments = 10, gap = "normal", surface = "transparent",
+    contrast = "auto", motion = "essential",
+    compact = "six square blocks",
+  },
+  [6] = {
+    key = "signal-ticks", label = "Signal Ticks",
+    face = "ticks", palette = "theme", direction = "auto",
+    origin = "scale-low", thickness = "medium", ends = "square",
+    segments = 20, gap = "tight", surface = "transparent",
+    contrast = "auto", motion = "refined",
+    compact = "ten high-contrast ticks",
+  },
+  [7] = {
+    key = "rc-center", label = "RC Center",
+    face = "dual-rail", palette = "custom-two", direction = "auto",
+    origin = "zero", thickness = "medium", ends = "round",
+    segments = 10, gap = "normal", surface = "transparent",
+    contrast = "auto", motion = "refined",
+    compact = "zero-notch dual rail",
+  },
+  [8] = {
+    key = "minimal-line", label = "Minimal Line",
+    face = "continuous", palette = "theme", direction = "auto",
+    origin = "scale-low", thickness = "thin", ends = "round",
+    segments = 8, gap = "tight", surface = "transparent",
+    contrast = "off", motion = "essential",
+    compact = "one-pixel-equivalent theme line",
+  },
+  [9] = {
+    key = "bold-data", label = "Bold Data",
+    face = "continuous", palette = "classic", direction = "auto",
+    origin = "scale-low", thickness = "thick", ends = "round",
+    segments = 12, gap = "normal", surface = "theme-panel",
+    contrast = "auto", motion = "refined",
+    compact = "medium rail with external value",
+  },
+}
+M.PRESETS = PRESETS
+
+-- Auto Source may choose the signal-strength reading model without adding a
+-- tenth user-facing preset. It is immutable resolver data like PRESETS: RSSI
+-- and link-quality values get the familiar rising bars, while SNR and other
+-- genuinely fast signed/noisy signal metrics retain Fine Ticks.
+local AUTO_SIGNAL_STEPS = {
+  key = "auto-signal-steps", label = "Stepped Signal",
+  face = "steps", palette = "classic", direction = "auto",
+  origin = "scale-low", thickness = "medium", ends = "square",
+  segments = 8, gap = "normal", surface = "transparent",
+  contrast = "auto", motion = "refined",
+  compact = "five rising signal steps",
+}
+
+local FACE = { [2] = "continuous", [3] = "blocks", [4] = "hex",
+               [5] = "ticks", [6] = "steps", [7] = "dual-rail" }
+local DIRECTION = { [2] = "horizontal", [3] = "vertical" }
+local ORIGIN = { [2] = "scale-low", [3] = "zero" }
+local THICKNESS = { [2] = "thin", [3] = "medium", [4] = "thick",
+                    [5] = "maximum" }
+local ENDS = { [2] = "round", [3] = "square", [4] = "chamfer" }
+local SEGMENTS = { [2] = 6, [3] = 8, [4] = 10, [5] = 12,
+                   [6] = 16, [7] = 24 }
+local GAP = { [2] = "tight", [3] = "normal", [4] = "wide" }
+local PALETTE = { [2] = "classic", [3] = "theme", [4] = "custom-three",
+                  [5] = "custom-two" }
+local SURFACE = { [2] = "transparent", [3] = "theme-panel",
+                  [4] = "custom" }
+local CONTRAST = { [2] = "off", [3] = "strong" }
+local MOTION = { [2] = "off", [3] = "essential", [4] = "refined",
+                 [5] = "expressive" }
+local HEAD = { [2] = "none", [3] = "cap", [4] = "dot", [5] = "line",
+               [6] = "needle" }
+local MARKS = { [2] = "off", [3] = "thresholds", [4] = "ends",
+                [5] = "full" }
+local VALUE_POS = { [2] = "above", [3] = "inside", [4] = "end",
+                    [5] = "off" }
+local LABEL_POS = { [2] = "above", [3] = "below", [4] = "inside",
+                    [5] = "off" }
+
+local THEME_ROLES = {
+  COLOR_THEME_PRIMARY1, COLOR_THEME_PRIMARY2,
+  COLOR_THEME_SECONDARY1, COLOR_THEME_SECONDARY2, COLOR_THEME_SECONDARY3,
+  COLOR_THEME_ACTIVE, COLOR_THEME_WARNING, COLOR_THEME_DISABLED,
+}
+
+local function pick(index, values, inherited)
+  return values[index] or inherited
+end
+
+local function hasReason(list, reason)
+  for i = 1, #list do
+    if list[i] == reason then return true end
+  end
+  return false
+end
+
+local function addDowngrade(visual, reason)
+  if not hasReason(visual.downgrades, reason) then
+    visual.downgrades[#visual.downgrades + 1] = reason
+  end
+end
+
+-- Convert renderer-facing downgrade strings into a user-facing diagnostic
+-- only when the pilot made an explicit choice that could not be honoured.
+-- Auto/preset responsiveness remains silent: it is the purpose of Auto.
+-- The full reason stays available for support while the retained UI only has
+-- to render the bounded, translated-independent word "LIMIT".
+function M.syncNotices(visual, cfg)
+  if not visual then return nil end
+  cfg = cfg or {}
+  local notices = {}
+  for i = 1, #(visual.downgrades or {}) do
+    local reason = visual.downgrades[i]
+    local explicit, requested, effective = false, reason, "responsive"
+    if reason == "motion-responsive" then
+      explicit = cfg.motion == 5
+      requested, effective = "expressive", visual.effectiveMotion
+    elseif reason == "dual-rail-requires-zero-origin"
+        or reason == "dual-rail-zero-outside-range" then
+      explicit = cfg.barFace == 7 or cfg.barPreset == 7
+        or (cfg.barOrigin or 1) > 1
+      requested, effective = "dual-rail", visual.face
+    elseif reason == "zero-origin-clamped" then
+      explicit = cfg.barOrigin == 3 or cfg.barPreset == 7
+      requested, effective = "zero", "scale-bound"
+    elseif string.sub(reason, 1, 8) == "segments" then
+      explicit = (cfg.segments or 1) > 1
+      requested = SEGMENTS[cfg.segments] or visual.segments
+      effective = visual.renderedSegments or visual.segments
+    elseif reason == "blocks-chamfer-to-square" then
+      explicit = cfg.barEnds == 4
+      requested, effective = "chamfer", visual.ends
+    elseif reason == "surface-compact" then
+      explicit = (cfg.surface or 1) > 1
+      requested, effective = SURFACE[cfg.surface] or "panel", visual.surface
+    elseif reason == "hex-compact-blocks" then
+      explicit = cfg.barFace == 4 or cfg.barPreset == 4
+      requested, effective = "hex", "compact-blocks"
+    elseif string.sub(reason, 1, 19) == "face-phase-pending:" then
+      explicit = (cfg.barFace or 1) > 1
+      requested, effective = visual.requestedFace, "continuous"
+    elseif string.sub(reason, 1, 6) == "theme-" then
+      explicit = (cfg.palette or 1) > 1 or (cfg.surface or 1) > 1
+      requested, effective = "theme-role", "safe-color"
+    end
+    if explicit then
+      notices[#notices + 1] = {
+        requested = requested,
+        effective = effective,
+        reason = reason,
+        explicit = true,
+        text = "LIMIT",
+      }
+    end
+  end
+  visual.notices = notices
+  visual.notice = notices[1]
+  return visual.notice
+end
+
+local function zoneProfile(zone)
+  local w = max(1, tonumber(zone and zone.w) or 1)
+  local h = max(1, tonumber(zone and zone.h) or 1)
+  local short = min(w, h)
+  local ratio, area = w / h, w * h
+  local family
+  if h <= 45 or w <= 74 then
+    family = "micro"
+  elseif ratio >= 2.2 and h <= 64 then
+    family = "short"
+  elseif h / w >= 1.55 then
+    family = "tall"
+  elseif w >= 400 or area >= 60000 then
+    family = "large"
+  elseif short <= 70 or area < 10000 then
+    family = "compact"
+  else
+    family = "standard"
+  end
+  return {
+    w = w, h = h, ratio = ratio, family = family,
+    compact = family == "micro" or family == "short"
+      or family == "compact",
+  }
+end
+M.zoneProfile = zoneProfile
+
+local function autoDirection(profile)
+  return (profile.ratio < 0.8) and "vertical" or "horizontal"
+end
+
+local function sourcePreset(kind, source, cfg)
+  if kind == "signal" then
+    local name = (SENSOR_PRESETS and SENSOR_PRESETS.normName)
+      and SENSOR_PRESETS.normName(source and source.name) or ""
+    if string.find(name, "rssi", 1, true)
+       or string.find(name, "rss", 1, true)
+       or string.find(name, "qly", 1, true)
+       or string.find(name, "vfr", 1, true) then
+      return AUTO_SIGNAL_STEPS
+    end
+    return PRESETS[6]
+  end
+  if kind == "battery" then return PRESETS[4] end
+  if kind == "capacity" then return PRESETS[5] end
+  if kind == "control" and cfg and cfg.min < 0 and cfg.max > 0 then
+    return PRESETS[7]
+  end
+  return PRESETS[2]
+end
+
+local function compactCount(face, count, profile)
+  if face == "blocks" then
+    if profile.compact then count = min(count,
+      (profile.family == "micro") and 6 or 10) end
+    return max(6, min(24, count))
+  elseif face == "hex" then
+    if profile.compact then count = min(count, 6) end
+    return max(6, min(10, count))
+  elseif face == "ticks" then
+    if profile.compact then count = min(count,
+      (profile.family == "micro") and 8 or 12) end
+    return max(8, min(28, count))
+  elseif face == "steps" then
+    if profile.compact then count = min(count, 5) end
+    return max(5, min(10, count))
+  end
+  return count
+end
+
+local function signature(parts)
+  for i = 1, #parts do parts[i] = tostring(parts[i]) end
+  return table.concat(parts, ":")
+end
+
+function M.configSignature(cfg)
+  return signature{
+    cfg.barPreset, cfg.barFace, cfg.barDir, cfg.barOrigin, cfg.barSize,
+    cfg.barEnds, cfg.segments, cfg.segGap, cfg.palette, cfg.warnClr,
+    cfg.critClr, cfg.trackClr, cfg.surface, cfg.panelClr, cfg.contrast,
+    cfg.motion, cfg.barHead, cfg.scaleMarks, cfg.valuePos, cfg.labelPos,
+  }
+end
+
+-- Theme role flags are stable IDs; their resolved RGB values change when HTX
+-- loads another theme. This is deliberately small enough to poll once per
+-- second on firmware that does not call widget.update() for a theme switch.
+function M.themeSignature()
+  return T.colorSignature(THEME_ROLES)
+end
+
+local function runtimeColor(color)
+  return T.resolveColor(color) or color
+end
+
+local function paletteInputSignature(cfg, visual, themeSig)
+  return signature{
+    visual.palette, visual.surface, visual.contrast,
+    cfg.accent, cfg.warnClr, cfg.critClr, cfg.trackClr, cfg.panelClr,
+    themeSig,
+  }
+end
+
+local function paletteFor(cfg, visual, themeSig, inputSig)
+  local normalSource = cfg.accent or T.color.accent
+  local warningSource, criticalSource = T.color.warn, T.color.crit
+  local mode = visual.palette
+
+  -- The backdrop the DATA is actually read against. With a panel it is the
+  -- panel; with a transparent surface it is whatever the home screen paints,
+  -- which is the theme's own SECONDARY3. Every contrast decision below has to
+  -- use this, not the track: a thin or segmented face barely touches the
+  -- track, so measuring against the track alone let a 1.14:1 fill through.
+  local backdrop = runtimeColor(
+    (visual.surface == "custom" and cfg.panelClr) or COLOR_THEME_SECONDARY3)
+
+  local themeDowngrade
+  if mode == "theme" then
+    -- COLOR_THEME_ACTIVE is the CHECKED-control background, not an instrument
+    -- colour: it is #ffde00 at 1.13:1 on the stock theme, which is exactly why
+    -- theme.color stopped using it (see theme.lua's status-colour comment).
+    -- Adopt it only where it survives the same 3:1 floor a fixed colour must
+    -- clear; otherwise keep the calibrated accent and say so.
+    local candidate = runtimeColor(COLOR_THEME_ACTIVE)
+    local ratio = T.contrastRatio(candidate, backdrop)
+    if ratio and ratio < 3 then
+      themeDowngrade = string.format("theme-normal-contrast-%.2f", ratio)
+    else
+      normalSource = COLOR_THEME_ACTIVE
+    end
+    local warnCandidate = runtimeColor(COLOR_THEME_WARNING)
+    local warnRatio = T.contrastRatio(warnCandidate, backdrop)
+    if warnRatio and warnRatio < 3 then
+      themeDowngrade = (themeDowngrade and (themeDowngrade .. "+warning"))
+        or string.format("theme-warning-contrast-%.2f", warnRatio)
+    else
+      warningSource = COLOR_THEME_WARNING
+    end
+  elseif mode == "custom-three" then
+    warningSource = cfg.warnClr or T.color.warn
+    criticalSource = cfg.critClr or T.color.crit
+  elseif mode == "custom-two" then
+    criticalSource = cfg.critClr or T.color.crit
+    warningSource = T.mixColor(criticalSource, normalSource, 0.5)
+  end
+
+  local customSurface = visual.surface == "custom"
+  local trackSource = customSurface and (cfg.trackClr or T.color.rail)
+                      or T.color.rail
+  local panelSource = customSurface and (cfg.panelClr or COLOR_THEME_SECONDARY3)
+                      or COLOR_THEME_SECONDARY3
+  local normal, warning, critical = runtimeColor(normalSource),
+    runtimeColor(warningSource), runtimeColor(criticalSource)
+  local track, panel = runtimeColor(trackSource), runtimeColor(panelSource)
+  local palette = {
+    mode = mode,
+    normal = normal, warning = warning, critical = critical,
+    track = track, panel = panel,
+    border = runtimeColor(COLOR_THEME_SECONDARY1),
+    history = runtimeColor(T.color.history), muted = runtimeColor(T.color.muted),
+    value = runtimeColor(T.color.value), label = runtimeColor(T.color.label),
+    inkDark = runtimeColor(T.color.inkDark),
+    inkLite = runtimeColor(T.color.inkLite),
+    sources = {
+      normal = normalSource, warning = warningSource, critical = criticalSource,
+      track = trackSource, panel = panelSource,
+    },
+  }
+  -- A custom panel is an authored background, so theme text roles are not
+  -- automatically safe on it. Preserve the panel byte-for-byte and select
+  -- whichever existing theme ink reads best on top; no user color is altered.
+  if customSurface then
+    local panelInk = T.labelOn(panel, palette)
+    palette.value, palette.label = panelInk, panelInk
+    palette.border, palette.history = panelInk, panelInk
+  end
+  palette.calibrated = mode == "classic" and normalSource == T.color.accent
+    and warningSource == T.color.warn and criticalSource == T.color.crit
+  palette.themeSignature = themeSig or M.themeSignature()
+  palette.inputSignature = inputSig
+    or paletteInputSignature(cfg, visual, palette.themeSignature)
+  palette.signature = mode .. ":" .. T.colorSignature{
+    normal, warning, critical, track, panel, palette.border,
+    palette.history, palette.muted, palette.value, palette.label,
+    palette.inkDark, palette.inkLite,
+  }
+
+  local nw = T.colorDistance(normal, warning)
+  local wc = T.colorDistance(warning, critical)
+  local nt = T.contrastRatio(normal, track)
+  local wt = T.contrastRatio(warning, track)
+  local ct = T.contrastRatio(critical, track)
+  -- Against the surface the data is read on, not only against the track. A
+  -- Thin or Ticks face puts almost no track under its own colour, so this is
+  -- the measurement that decides whether the reading is visible at all.
+  local nb = T.contrastRatio(normal, backdrop)
+  local wb = T.contrastRatio(warning, backdrop)
+  local cb = T.contrastRatio(critical, backdrop)
+  local basicNeed = (nw and nw < 60) or (wc and wc < 60)
+    or (nt and nt < 3) or (wt and wt < 3) or (ct and ct < 3)
+    or (nb and nb < 3) or (wb and wb < 3) or (cb and cb < 3) or false
+  local nwCvd, wcCvd
+  -- Matrix simulation is the expensive fallback, not a tax on every widget
+  -- configure. If ordinary separation/contrast already requires assistance,
+  -- the decision is complete and the redundant WARN/CRIT channel is enabled.
+  if not basicNeed then
+    local nwProtan = T.colorVisionDistance(normal, warning, "protanopia")
+    local nwDeutan = T.colorVisionDistance(normal, warning, "deuteranopia")
+    local nwTritan = T.colorVisionDistance(normal, warning, "tritanopia")
+    local wcProtan = T.colorVisionDistance(warning, critical, "protanopia")
+    local wcDeutan = T.colorVisionDistance(warning, critical, "deuteranopia")
+    local wcTritan = T.colorVisionDistance(warning, critical, "tritanopia")
+    nwCvd = nwProtan and min(nwProtan, nwDeutan, nwTritan) or nil
+    wcCvd = wcProtan and min(wcProtan, wcDeutan, wcTritan) or nil
+  end
+  palette.backdrop = backdrop
+  palette.themeDowngrade = themeDowngrade
+  palette.analysis = {
+    normalWarningDistance = nw,
+    warningCriticalDistance = wc,
+    normalTrackContrast = nt,
+    warningTrackContrast = wt,
+    criticalTrackContrast = ct,
+    normalBackdropContrast = nb,
+    warningBackdropContrast = wb,
+    criticalBackdropContrast = cb,
+    normalWarningCvdDistance = nwCvd,
+    warningCriticalCvdDistance = wcCvd,
+  }
+  palette.needsAssist = basicNeed or (nwCvd and nwCvd < 45)
+    or (wcCvd and wcCvd < 45) or false
+  palette.assist = (visual.contrast == "strong") and "strong"
+    or (visual.contrast == "off") and "off"
+    or (palette.needsAssist and "needed" or "none")
+  return palette
+end
+
+-- Resolve without writing to cfg or widget.options. The caller owns the two
+-- returned per-instance tables; PRESETS and shared module state stay read-only.
+function M.resolve(widget, cfg)
+  assert(T, "GaugePro: bar_style.setup was not called")
+  cfg = cfg or {}
+  local profile = zoneProfile(widget and widget.zone)
+  local selected = PRESETS[cfg.barPreset] or PRESETS[2]
+  local hint = (SENSOR_PRESETS and SENSOR_PRESETS.kind)
+    and SENSOR_PRESETS.kind(widget and widget.source) or "generic"
+  local inherited = selected.sourceAware
+    and sourcePreset(hint, widget and widget.source, cfg) or selected
+
+  local visual = {
+    preset = selected.key,
+    inheritedPreset = inherited.key,
+    sourceHint = hint,
+    requestedFace = pick(cfg.barFace, FACE, inherited.face),
+    direction = pick(cfg.barDir, DIRECTION, inherited.direction),
+    origin = pick(cfg.barOrigin, ORIGIN, inherited.origin),
+    thickness = pick(cfg.barSize, THICKNESS, inherited.thickness),
+    ends = pick(cfg.barEnds, ENDS, inherited.ends),
+    segments = pick(cfg.segments, SEGMENTS, inherited.segments),
+    segmentsAuto = SEGMENTS[cfg.segments] == nil,
+    gap = pick(cfg.segGap, GAP, inherited.gap),
+    palette = pick(cfg.palette, PALETTE, inherited.palette),
+    surface = pick(cfg.surface, SURFACE, inherited.surface),
+    contrast = pick(cfg.contrast, CONTRAST, inherited.contrast),
+    motion = pick(cfg.motion, MOTION, inherited.motion or "refined"),
+    head = pick(cfg.barHead, HEAD, inherited.head or "line"),
+    marks = pick(cfg.scaleMarks, MARKS, inherited.marks or "auto"),
+    valuePos = pick(cfg.valuePos, VALUE_POS, inherited.valuePos or "auto"),
+    labelPos = pick(cfg.labelPos, LABEL_POS, inherited.labelPos or "auto"),
+    compactDescription = inherited.compact,
+    profile = profile,
+    downgrades = {},
+  }
+  visual.effectiveMotion = visual.motion
+  visual.motionReduced = false
+  if visual.motion == "expressive"
+     and (profile.family == "micro" or profile.family == "short") then
+    visual.effectiveMotion = "refined"
+    visual.motionReduced = true
+    addDowngrade(visual, "motion-responsive")
+  end
+  visual.face = visual.requestedFace
+  if visual.direction == "auto" then visual.direction = autoDirection(profile) end
+
+  if visual.face == "dual-rail" and ORIGIN[cfg.barOrigin] == nil then
+    visual.origin = "zero"
+  elseif visual.face == "dual-rail" and visual.origin ~= "zero" then
+    visual.face = "continuous"
+    addDowngrade(visual, "dual-rail-requires-zero-origin")
+  end
+
+  local lo, hi = min(cfg.min or 0, cfg.max or 0), max(cfg.min or 0, cfg.max or 0)
+  local zeroInside = lo <= 0 and hi >= 0
+  local signedZero = lo < 0 and hi > 0
+  visual.zeroInside = zeroInside
+  if visual.origin == "zero" and not zeroInside then
+    addDowngrade(visual, "zero-origin-clamped")
+  end
+  if visual.face == "dual-rail" and not signedZero then
+    visual.face = "continuous"
+    visual.origin = "scale-low"
+    addDowngrade(visual, "dual-rail-zero-outside-range")
+  end
+
+  if visual.face == "ticks" and visual.segmentsAuto
+     and profile.family == "large" then
+    visual.segments = 28
+  end
+  local requestedCount = visual.segments
+  visual.segments = compactCount(visual.face, visual.segments, profile)
+  if visual.segments ~= requestedCount then
+    local reason = (not profile.compact and visual.segments < requestedCount)
+      and "segments-object-budget" or "segments-responsive"
+    addDowngrade(visual, reason)
+  end
+  if visual.face == "blocks" and visual.ends == "chamfer" then
+    visual.ends = "square"
+    addDowngrade(visual, "blocks-chamfer-to-square")
+  end
+  if profile.family == "micro" and visual.surface ~= "transparent" then
+    visual.surface = "transparent"
+    addDowngrade(visual, "surface-compact")
+  end
+
+  visual.configSig = M.configSignature(cfg)
+  visual.structuralSig = signature{
+    visual.face, visual.direction, visual.origin, visual.thickness,
+    visual.ends, visual.segments, visual.gap, visual.surface, profile.family,
+    visual.head, visual.marks, visual.valuePos, visual.labelPos,
+  }
+  local previous = widget and widget.barPalette
+  -- Geometry-only settings edits are common and the live one-second probe is
+  -- already the authority for theme drift. Reuse the current palette without
+  -- eight lcd.getColor calls when its actual inputs are unchanged; if a
+  -- palette/surface/color input moved, resolve the live roles immediately.
+  local themeSig = previous and previous.themeSignature or M.themeSignature()
+  local inputSig = paletteInputSignature(cfg, visual, themeSig)
+  local palette
+  if previous and previous.inputSignature == inputSig then
+    palette = previous
+  else
+    themeSig = M.themeSignature()
+    inputSig = paletteInputSignature(cfg, visual, themeSig)
+    palette = paletteFor(cfg, visual, themeSig, inputSig)
+  end
+  visual.paletteSig = palette.signature
+  visual.themeSig = palette.themeSignature
+  -- Recorded on `visual`, resolved on `palette`: the palette is memoised by
+  -- input signature, so the reason has to be copied here on every resolve
+  -- rather than appended inside paletteFor, which would duplicate it.
+  if palette.themeDowngrade then
+    addDowngrade(visual, palette.themeDowngrade)
+  end
+  M.syncNotices(visual, cfg)
+  if widget then
+    local now = (type(getTime) == "function") and getTime() or 0
+    if palette ~= previous or widget.barThemeCheckAt == nil then
+      widget.barThemeCheckAt = now + 100
+    end
+  end
+  return visual, palette
+end
+
+-- Re-resolve the palette at most once per second and only when a role's
+-- resolved RGB actually changed. No geometry signature is touched: the bar
+-- update path sees the new palette signature and recolors retained objects.
+function M.refreshPalette(widget, cfg, now)
+  if not widget or not widget.barVisual or not widget.barPalette then return false end
+  now = tonumber(now) or ((type(getTime) == "function") and getTime() or 0)
+  local due = widget.barThemeCheckAt or 0
+  if now < due then return false end
+  widget.barThemeCheckAt = now + 100
+  local themeSig = M.themeSignature()
+  if themeSig == widget.barVisual.themeSig then return false end
+  cfg = cfg or widget.config or {}
+  local inputSig = paletteInputSignature(cfg, widget.barVisual, themeSig)
+  local palette = paletteFor(cfg, widget.barVisual, themeSig, inputSig)
+  widget.barPalette = palette
+  widget.barVisual.themeSig = palette.themeSignature
+  widget.barVisual.paletteSig = palette.signature
+  return true
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/dial_layout.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/dial_layout.lua
@@ -1,0 +1,735 @@
+---- Gauge Core - dial-only responsive layout -----------------------------
+
+local M = {}
+local floor, min, max = math.floor, math.min, math.max
+local C, T, G, F, SWEEPS
+local clamp, box, clipToChord, stackTextRows, placeValue
+
+function M.setup(common, theme, geometry, format)
+  C, T, G, F = common, theme, geometry, format
+  SWEEPS = C.SWEEPS
+  clamp, box = C.clamp, C.box
+  clipToChord, stackTextRows = C.clipToChord, C.stackTextRows
+  placeValue = C.placeValue
+end
+
+-- ------------------------------------------------------------------ dial --
+
+local function dialLayout(widget, cfg, L, w, h)
+  local mode, orientation = L.mode, L.orientation
+  -- Phase 1's instrument composition is deliberately narrow in scope. The
+  -- compact horizontal family and every balanced/vertical family retain their
+  -- established geometry; only a horizontal face with room for both title
+  -- and value gets the explicit header/main/footer structure.
+  local horizontalInstrument = orientation == "horizontal"
+    and (mode == "normal" or mode == "large")
+  L.horizontalInstrument = horizontalInstrument
+  -- A 60x60 micro dial has no name, unit, state chip, history, or needle.
+  -- Keeping the normal six-pixel frame around that already-minimal face made
+  -- its safe inner chord narrower than "16.62" at the smallest EdgeTX font.
+  -- Let containment own the real one-pixel edge limit instead; larger faces
+  -- retain their normal breathing room.
+  local pad = (mode == "micro") and 0 or T.px(T.space.md)
+  local sweep = SWEEPS[cfg.sweep or C.SWEEP_270] or SWEEPS[C.SWEEP_270]
+  L.startAngle, L.sweep = sweep[1], sweep[2]
+  local side = min(w, h)
+
+  L.showUnit = mode ~= "micro"
+  L.showName = (mode == "normal" or mode == "large")
+  -- ShowChip (owner request, Tanda 5): the no-data pill is opt-out, not
+  -- mandatory. The ROW is reserved either way (Tanda 8 F9): `Off` now hides
+  -- only the informational chips and never WARN or CRIT, so the space has to
+  -- exist whatever the option says, or a warning badge would land on top of
+  -- the name. What the option costs is one text row in the layouts that stack
+  -- it - horizontal zones and the bar; on the square and vertical dials the
+  -- badge rides ON the dial and was never part of the budget.
+  L.showState = mode ~= "micro"
+  L.showMarkers = (cfg.showMinMax or 1) > 1 and mode ~= "micro"
+  -- No `mode == "large"` gate. That gate wanted a short side of 180 * LCD_SCALE
+  -- (~300 px on an 800x480 radio), which the most common half-screen zone -
+  -- 400x240 - never reaches, so the third choice of a published option did
+  -- nothing on the layouts people actually use. Fit is decided lower down by
+  -- minMaxTextFits() against the real captions, which is the honest test and
+  -- already degrades to the marks when the cells are too narrow.
+  L.showMinMaxText = (cfg.showMinMax or 1) > 2 and mode ~= "micro"
+  -- a full ring starts and ends at the same point: two scale labels would sit
+  -- on top of each other
+  -- A 400x160 face classifies as normal, although its dedicated dial half has
+  -- enough room for both endpoint labels. Treat large as an unconditional
+  -- candidate and the new horizontal instrument as a fit-tested candidate;
+  -- the final geometry below can still reject both labels as one unit.
+  L.showScale = (mode == "large" or horizontalInstrument) and (L.sweep < 360)
+  L.showGhost = (mode ~= "micro")
+
+  -- The name is the least important text on the dial: the smallest font keeps
+  -- the hierarchy value -> unit -> name clean (review P2-10). The state text
+  -- stays one step larger because WARN/CRIT carry the severity.
+  L.nameFont = T.FONTS.XXS
+  L.stateFont = T.FONTS.XS
+  L.minMaxFont = T.FONTS.XXS
+  L.scaleFont = T.FONTS.XXS
+  local nameH = T.fontHeight(L.nameFont)
+  local stateH = T.fontHeight(L.stateFont)
+  local minMaxH = T.fontHeight(L.minMaxFont)
+
+  -- The badge's complete footprint belongs to layout, including its outline.
+  -- Computing it before the horizontal bands means the header reserves the
+  -- exact same geometry that dial_renderer and ui_core later paint.
+  L.chipPad = T.px(7)
+  L.chipHeight = stateH + T.px(6)
+  L.chipOff = floor((L.chipHeight - stateH) / 2)
+  L.chipOutline = T.px(1)
+
+  -- "Markers + text" is a preference, not permission to wrap telemetry
+  -- captions. Evaluate it before carving a footer so a failed fit gives every
+  -- pixel back to the value instead of leaving a blank reserved band.
+  local minCaption = "min " .. F.display(widget, cfg.min)
+  local maxCaption = "max " .. F.display(widget, cfg.max)
+  local minMaxCellNeed = max(T.textWidth(minCaption, L.minMaxFont),
+                             T.textWidth(maxCaption, L.minMaxFont))
+  local function minMaxTextFits(b)
+    return floor(b.w / 2) >= minMaxCellNeed
+  end
+
+  -- dial box and text region per orientation
+  local dial, textRegion, valueRegion
+  if orientation == "horizontal" then
+    -- The dial takes the full zone HEIGHT and the text column keeps only the
+    -- width it needs. `min(w*0.5, h)` strangled the dial to half the zone
+    -- even when there was height to spare, wasting up to ~73 % of the area
+    -- (AUDIT.md G-13: 480x272 used 27 %). The column floor - the value at its
+    -- smallest font plus the longest label row - keeps the text legible, and
+    -- the max() with the old half-width rule means a narrow horizontal zone
+    -- never loses dial size.
+    local textMin = max(T.px(120), floor(w * 0.28))
+    local dialSide = max(min(w - textMin, h), min(w * 0.5, h))
+    dial = box(pad, pad, dialSide - pad * 2, h - pad * 2)
+    local tx = dial.x + dial.w + T.px(T.space.md)
+    textRegion = box(tx, pad, w - tx - pad, h - pad * 2)
+    if horizontalInstrument then
+      if L.showMinMaxText and not minMaxTextFits(textRegion) then
+        L.showMinMaxText = false
+      end
+      local headerH = max(L.showName and nameH or 0,
+                          L.showState
+                            and (L.chipHeight + L.chipOutline * 2) or 0)
+      local footerH = L.showMinMaxText and minMaxH or 0
+      local gap = T.px(T.space.sm)
+      L.headerBox = box(textRegion.x, textRegion.y, textRegion.w, headerH)
+      L.footerBox = box(textRegion.x,
+        textRegion.y + textRegion.h - footerH, textRegion.w, footerH)
+      local mainY = textRegion.y + headerH
+        + ((headerH > 0) and gap or 0)
+      local mainBottom = L.footerBox.y
+        - ((footerH > 0) and gap or 0)
+      L.mainBox = box(textRegion.x, mainY, textRegion.w,
+                      max(mainBottom - mainY, T.px(12)))
+      valueRegion = L.mainBox
+    else
+      local rows = (L.showName and nameH or 0) + (L.showState and stateH or 0)
+        + (L.showMinMaxText and minMaxH or 0)
+      valueRegion = box(textRegion.x, textRegion.y,
+                        textRegion.w, max(textRegion.h - rows, T.px(12)))
+    end
+  elseif orientation == "vertical" then
+    local dialSide = min(w, h * 0.62)
+    dial = box(floor((w - dialSide) / 2) + pad, pad,
+               dialSide - pad * 2, dialSide - pad * 2)
+    local ty = dial.y + dial.h + T.px(T.space.sm)
+    textRegion = box(pad, ty, w - pad * 2, h - ty - pad)
+    -- C6 (Tanda 7): `mode` is classified on min(w, h), so a very TALL zone is
+    -- judged by its NARROW axis - a 100x260 widget came out "compact" and
+    -- dropped its source name on 260 px of height. Mode still governs
+    -- everything else (tick count, fonts, scale labels, markers); the name
+    -- only needs somewhere to sit, and in a vertical zone that is measurable
+    -- directly. Promoting the whole mode instead would drag six other
+    -- decisions along with it for the sake of one label.
+    if not L.showName then
+      local smallest = T.fontHeight(T.RAMP[#T.RAMP])
+      L.showName = (textRegion.h - nameH - T.px(T.space.sm)) >= smallest
+    end
+    local rows = (L.showName and nameH or 0) + (L.showMinMaxText and minMaxH or 0)
+    valueRegion = box(textRegion.x, textRegion.y,
+                      textRegion.w, max(textRegion.h - rows, T.px(12)))
+  else
+    local nameSpace = L.showName and (nameH + T.px(T.space.xs)) or 0
+    local d = min(w, h - nameSpace)
+    dial = box(floor((w - d) / 2) + pad, pad, d - pad * 2, d - pad * 2)
+    textRegion = dial
+    -- value lives inside the dial circle. A micro dial draws no state chip
+    -- and no needle, so its value can sit in the MIDDLE of the circle, where
+    -- the clear chord is widest; larger modes must clear the state chip.
+    -- P0-2: the normal/large value region is dropped `valueDrop` px so the
+    -- text cell clears the pivot and the needle blade at critical angles
+    -- (measured: the cell used to start 6 px inside the pivot's vertical
+    -- span at 200x160). The min/max row below is chord-clipped further down,
+    -- and the region's own chord clip keeps the fit honest.
+    -- Tanda 7 B (closing Tanda 5 P1-5, which stayed 🟡 pending this decision).
+    -- valueDrop was px(7). It buys clearance from the pivot and the blade,
+    -- and it costs CHORD - and the chord is what picks the value font, so the
+    -- gauge's headline number was paying for it: 16 px on a 200x160 dial, the
+    -- same size as its own `min 31` caption, which flattens the hierarchy the
+    -- type ramp exists to express.
+    --
+    -- Tanda 7 A settled what the clearance is actually worth: the labels are
+    -- created AFTER the needle (renderer.build) and paint over it, so the
+    -- needle passing behind the digits was never a correctness problem - and
+    -- the owner accepted that look explicitly (Tanda 5 review 3.13 / P2-5).
+    -- What must stay clear is the PIVOT, a solid disc the digits would sit on
+    -- top of; px(3) still clears it, and the value cell's own chord clip keeps
+    -- the fit honest either way.
+    local valueDrop = T.px(3)
+    if mode == "micro" then
+      -- centred exactly on the dial centre: the clear chord is widest there,
+      -- and a micro dial's value is only a few px wide (no unit, no state)
+      valueRegion = box(dial.x, dial.y + floor(dial.h / 2)
+                        - floor(dial.h * 0.15),
+                        dial.w, floor(dial.h * 0.30))
+    elseif mode == "compact" then
+      valueRegion = box(dial.x, dial.y + floor(dial.h * 0.50),
+                        dial.w, floor(dial.h * 0.26))
+    else
+      valueRegion = box(dial.x, dial.y + floor(dial.h * 0.45) + valueDrop,
+                        dial.w, floor(dial.h * 0.26))
+    end
+  end
+
+  -- Exposed structural boxes are inexpensive layout data and make the visual
+  -- contract directly testable without inferring it from retained objects.
+  L.dialBox, L.textRegion = dial, textRegion
+
+  L.cx = dial.x + floor(dial.w / 2)
+  L.cy = dial.y + floor(dial.h / 2)
+
+  -- Resolve the presentation before the radial metrics: Needle uses a thin
+  -- active arc as a secondary position cue, while Arc keeps the full track
+  -- weight because it has no blade. Auto is Needle outside the micro family.
+  L.showNeedle = (cfg.style == C.STYLE_NEEDLE)
+    or (cfg.style == C.STYLE_AUTO and mode ~= "micro")
+
+  -- Ring metrics depend on the zone, not on the radius, so they are computed
+  -- first; the radius is then whatever is left after reserving room for
+  -- everything drawn OUTSIDE the track (rail, gap, ticks). Deriving the
+  -- radius from the box alone pushes the ticks past the zone edge.
+  L.trackThickness = clamp(floor(side * T.ratio.trackToRadius / 2),
+                           T.px(3), T.px(12))
+  L.arcThickness = L.showNeedle
+    and clamp(floor(L.trackThickness * T.ratio.needleArcToTrack + 0.5),
+              T.px(2), L.trackThickness)
+    or L.trackThickness
+  L.railThickness = max(T.px(2), floor(L.trackThickness * T.ratio.railToTrack))
+  L.ghostThickness = max(T.px(2), floor(L.trackThickness * 0.45))
+  L.tickCount = (mode == "micro") and 3 or ((mode == "large") and 7 or 5)
+  -- Minimum 2 px: at 1 px the scale marks vanished into the background on
+  -- dark themes (~2.5:1 contrast, review P-C). Micro ticks stay at exactly
+  -- two pixels: px(2) becomes three on the 800-class scale, whose half-stroke
+  -- crossed a 60 px stress zone even while its endpoints remained inside.
+  local minTick = (mode == "micro") and 2 or T.px(2)
+  L.tickThickness = clamp(floor(side / 90), minTick, T.px(3))
+  L.minorTicks = (mode == "large") and (L.tickCount - 1) or 0
+
+  local tickLength = clamp(floor(side / 40), T.px(2), T.px(6))
+  -- The micro face needs every radial pixel.  One pixel still separates its
+  -- three ticks from the rail and leaves their endpoints inside the zone;
+  -- larger faces keep the full xs rhythm.
+  local tickGap = (mode == "micro") and T.px(1) or T.px(T.space.xs)
+  -- Only Rail and Sections actually paint a reference band outside the track.
+  -- Reserving that band in Static, Threshold and Gradient left a visibly empty
+  -- annulus between the dial and its scale ticks (INFORME-DEFECTOS.md W-01).
+  -- Keep this fact here, before every radial budget is derived, so the dial
+  -- grows into the released room instead of merely moving the ticks outward.
+  L.hasReferenceBand = cfg.colorMode == C.COLOR_RAIL
+    or cfg.colorMode == C.COLOR_SECTIONS
+  L.railGap = T.px(1)
+  local referenceBandReserve = L.hasReferenceBand
+    and (L.railThickness + L.railGap) or 0
+  local outerReserve = floor(L.trackThickness / 2) + referenceBandReserve
+    + tickGap + tickLength + 1
+  local half = floor(min(dial.w, dial.h) / 2)
+  L.radius = max(half - outerReserve, T.px(8))
+  -- The rail band radius clears the value arc's outer edge by `railGap`: when
+  -- the value is critical both layers are red at adjacent radii, and touching
+  -- them read as one bevelled blob (review P-E). The 1 px band gap keeps the
+  -- red->amber transition a clean range boundary.
+  -- CONTAINMENT. `radius` above has a px(8) FLOOR, so in a zone smaller than
+  -- the ring's own outer furniture the subtraction goes negative, the floor
+  -- wins, and everything derived from the radius is then pushed OUTSIDE the
+  -- zone - the ticks first, since they are the outermost thing on the dial.
+  --
+  -- That is not a cosmetic overflow. Ticks and history marks are LINES, and
+  -- LvglWidgetLine::getPt reads their coordinates with luaL_checkunsigned
+  -- (lua_lvgl_widget.cpp:1001,1004): a negative one RAISES on the radio, so
+  -- the widget dies on its first build and disables itself for the session -
+  -- the coordinate-validation harness exists to catch. Measured
+  -- before this clamp: every zone below ~32x32 at LCD_SCALE 1.0 (46x46 at
+  -- 1.375) built negative tick coordinates.
+  --
+  -- So give up the outer FURNITURE rather than the widget, in ascending order
+  -- of importance: the ticks first (a 30 px dial cannot resolve them anyway),
+  -- then the ring shrinks onto whatever is left. `edgeReach` is the clearance
+  -- from the dial centre to the nearest zone edge - the real budget, which
+  -- the dial BOX alone does not capture once the box has been centred.
+  local edgeReach = min(L.cx, L.cy, w - L.cx, h - L.cy) - 1
+  local railOut = floor(L.trackThickness / 2) + referenceBandReserve
+  if L.radius + railOut + tickGap + tickLength > edgeReach then
+    local r = edgeReach - railOut - tickGap - tickLength
+    if r >= T.px(8) then
+      L.radius = r                       -- ticks still fit: just shrink
+    else
+      L.tickCount, L.minorTicks, tickLength = 0, 0, 0
+      L.radius = max(edgeReach - railOut - T.px(1), T.px(3))
+    end
+  end
+
+  L.railRadius = L.radius + floor(L.trackThickness / 2)
+    + referenceBandReserve
+  L.tickInner = L.railRadius + tickGap
+  L.tickOuter = L.tickInner + tickLength
+  -- Threshold is an exact boundary, not another scale tick. Its radial line
+  -- spans the complete neutral track, then adds a bounded 1..2 px lip towards
+  -- the ticks. Thickness is always at least one physical step above a normal
+  -- tick and remains capped by the LCD-scaled stroke budget.
+  L.thresholdLip = clamp(
+    floor(L.trackThickness * T.ratio.thresholdLipToTrack + 0.5),
+    T.px(1), T.px(2))
+  L.thresholdInner = max(L.radius - floor(L.trackThickness / 2), 0)
+  L.thresholdOuter = min(
+    L.radius + floor((L.trackThickness + 1) / 2) + L.thresholdLip,
+    L.tickInner, max(edgeReach, 0))
+  L.thresholdOuter = max(L.thresholdOuter, L.thresholdInner)
+  L.thresholdThickness = clamp(L.tickThickness + T.px(1),
+                               T.px(2), T.px(4))
+  -- Radial span of the min/max history marks. LAYOUT data, like the bar's
+  -- markOverhang: renderer.build and renderer.updateHistory both need it and
+  -- used to compute the same two expressions independently - the exact shape
+  -- of drift that put the state pill outside its zone.
+  -- Both ends are clamped for the same luaL_checkunsigned reason as above:
+  -- `edgeReach` caps the outer end in the degenerate zones the branch above
+  -- lands in, and 0 caps the inner one, which goes negative once the ring is
+  -- thicker than the radius it was squeezed onto.
+  L.markInner = max(L.radius - floor(L.trackThickness / 2) - T.px(1), 0)
+  L.markOuter = min(L.railRadius + T.px(1), max(edgeReach, 0))
+
+  -- In a balanced zone the value text hangs inside the dial circle, and the
+  -- circle's clear interior at that height is a CHORD of the ring - narrower
+  -- than the dial box. Centering the value+unit group against the full box
+  -- width pushes the unit (and wide values) onto the ring, exactly the
+  -- LABEL/RING collisions the audit measured (AUDIT.md G-6). Horizontal/
+  -- vertical zones place the value outside the dial and do not need it.
+  --
+  -- The region itself is NO LONGER pre-clipped: placeValue now measures the
+  -- chord per candidate font, at the bottom of the box that font would really
+  -- occupy (see pickValueFont). Pre-clipping here would re-impose the
+  -- region-depth chord as a ceiling and undo exactly that (Tanda 7 B).
+  local chordCtx = (orientation == "balanced")
+    and { L = L, region = valueRegion } or nil
+
+  -- needle
+  if L.showNeedle then
+    L.pivotRadius = clamp(floor(L.radius * T.ratio.pivotRadius),
+                          T.px(3), T.px(9))
+    -- The blade has to START inside the hub. It used to begin at 0.16 * radius
+    -- while the hub ended at 0.09 * radius (T.ratio.pivotRadius), so a gap of
+    -- 0.07 * radius - 4 px on a 200x160 zone - always separated the needle
+    -- from its own pivot and the needle read as floating. Overlapping by one
+    -- pixel is what makes the two look like one object at every size; the hub
+    -- is drawn after the blade, so the overlap is never visible as a seam.
+    L.needleInner = min(clamp(floor(L.radius * 0.16), T.px(3), T.px(20)),
+                        max(0, L.pivotRadius - 1))
+    L.needleOuter = L.radius - floor(L.trackThickness / 2) - T.px(1)
+    L.needleHalf = clamp(floor(L.radius * T.ratio.needleWidth), T.px(2), T.px(7))
+    -- Tapered blade from three LINES (P2-1 keeps the needle a line family):
+    -- base -> mid -> tip, each a bit thinner than the last, so the width
+    -- steps down gradually instead of jumping straight from the thick base
+    -- to the 2 px tip in one cut (Tanda 4's two-part P-A read as a paddle
+    -- with a toothpick glued on at anything above micro sizes; owner
+    -- request, Tanda 5). Each segment overlaps the previous by 75% of its
+    -- OWN thickness so the rounded caps (renderer.buildNeedle) blend into
+    -- one another instead of leaving a visible seam.
+    local reach = L.needleOuter - L.needleInner
+    L.needleBodyOuter = L.needleInner + floor(reach * T.ratio.needleBodyReach)
+    L.needleMidOuter = L.needleInner + floor(reach * T.ratio.needleMidReach)
+    L.needleMidHalf = clamp(floor(L.needleHalf * T.ratio.needleMidToHalf),
+                            1, L.needleHalf)
+    L.needleTipHalf = clamp(floor(L.needleHalf * T.ratio.needleTipToHalf),
+                            1, L.needleMidHalf)
+    L.needleTipThickness = max(T.px(2), L.needleTipHalf * 2)
+    L.needleMidInner = max(L.needleInner,
+                           L.needleBodyOuter - floor(L.needleMidHalf * 2 * 0.75))
+    L.needleTipInner = max(L.needleMidInner,
+                           L.needleMidOuter - floor(L.needleTipThickness * 0.75))
+  end
+
+  -- typography and text regions
+  local cap = (mode == "micro") and T.FONTS.XS
+    or ((mode == "compact") and T.FONTS.L or nil)
+  -- a unit that will not be drawn (micro zones) must not reserve width in the
+  -- value group: the chord a micro dial leaves for text is only a few px
+  -- (AUDIT.md G-6)
+  -- P0-2, re-expressed against the thing it actually protects. Runs HERE,
+  -- after the needle block, because L.pivotRadius does not exist before it.
+  --
+  -- `valueDrop` was a fixed px(7) nudge chosen to push the value cell clear of
+  -- the pivot hub and the blade. A fixed nudge cannot hold that guarantee once
+  -- the type can grow: the box is centred in its region, so a taller font
+  -- raises its own top edge and walks straight back onto the hub (measured at
+  -- 200x160 with the value at MIDSIZE: cell top 74, hub spanning 69..77).
+  --
+  -- The hub is a real, measurable disc, so clear THAT explicitly and let the
+  -- chord hand back whatever room is left. Top-aligning the value in the
+  -- region rather than centring it then puts the cell as high as the
+  -- guarantee allows, which is also where the chord is widest - the value
+  -- gets the largest font that genuinely fits without ever touching the hub.
+  -- Change A settled the other half of the old clearance: the labels are
+  -- created after the needle and paint over it, so the BLADE passing behind
+  -- the digits is by design (owner, Tanda 5 review 3.13 / P2-5).
+  if chordCtx and L.pivotRadius and mode ~= "micro" then
+    local hubBottom = L.cy + L.pivotRadius + T.px(2)
+    if valueRegion.y < hubBottom then
+      -- Move the region DOWN without shrinking it. Trimming the height to
+      -- keep the bottom edge fixed looks tidy and is wrong: `region.h` is the
+      -- height budget the font ramp is checked against, so a region trimmed
+      -- by 20 px rejected every candidate taller than what was left - a
+      -- 300x272 dial dropped two whole ramp steps (48 px to 32 px) with the
+      -- room still sitting unused below it. The box is top-aligned here, so
+      -- the height is a budget, not an extent: the CHORD is what actually
+      -- limits the font, and stackTextRows takes whatever is left below.
+      valueRegion.y = hubBottom
+    end
+    chordCtx.topAlign = true
+  end
+
+  local valuePolicy
+  if horizontalInstrument then
+    -- Phase 2 hierarchy for the explicit information column. The value stays
+    -- within the 35..45% reference band whenever the discrete EdgeTX ramp can
+    -- provide it; the unit then chooses the legible font closest to 40%, never
+    -- above 50%, and uses the tighter `sm` relationship. No other family
+    -- receives this table, so placeValue's established defaults remain exact.
+    valuePolicy = {
+      valueMaxHeight = floor(h * 0.45),
+      unitTargetRatio = 0.40,
+      unitMaxRatio = 0.50,
+      unitMinFont = T.FONTS.XS,
+      unitGap = T.px(T.space.sm),
+    }
+  end
+  placeValue(L, valueRegion, F.widestSample(widget),
+             L.showUnit and widget.unitText or "", cap, chordCtx, valuePolicy)
+
+  -- Rows BELOW the value, in paint order top to bottom. They are placed with
+  -- provisional geometry here and then stacked by stackTextRows, which owns
+  -- the vertical rhythm (Tanda 7 B); only the x/w/h of each box matter above.
+  local align = (orientation == "horizontal") and LEFT or CENTER
+  local stackTop, stackBottom, stackRows
+  if orientation == "horizontal" then
+    if horizontalInstrument then
+      -- One header, two owners. Reserve the longest informational badge rather
+      -- than today's state, so NORMAL -> WARN/CRIT/NO SOURCE never changes the
+      -- layout or walks the value vertically. The outline is kept inside the
+      -- header's right edge and the title receives the remaining width.
+      local stateReserve = min(textRegion.w,
+        T.textWidth("NO SOURCE", L.stateFont) + L.chipPad * 2)
+      local headerGap = T.px(T.space.sm)
+      local stateRight = L.headerBox.x + L.headerBox.w - L.chipOutline
+      local stateX = stateRight - stateReserve
+      local nameW = max(stateX - headerGap - L.headerBox.x, 1)
+      local nameY = L.headerBox.y
+        + floor((L.headerBox.h - nameH) / 2)
+      local stateY = L.headerBox.y
+        + floor((L.headerBox.h - stateH) / 2)
+      L.nameBox = box(L.headerBox.x, nameY, nameW, nameH)
+      L.stateBox = box(stateX, stateY, stateReserve, stateH)
+      L.minMaxBox = box(L.footerBox.x, L.footerBox.y,
+                        L.footerBox.w, minMaxH)
+      -- placeValue already centred the stable value+unit group in mainBox.
+      -- There is nothing left to distribute: title/state and history have
+      -- explicit bands and NORMAL simply hides its retained badge objects.
+      stackRows = {}
+      stackTop, stackBottom = 0, 0
+    else
+      L.stateBox = box(textRegion.x, 0, textRegion.w, stateH)
+      L.minMaxBox = box(textRegion.x, 0, textRegion.w, minMaxH)
+      L.nameBox = box(textRegion.x, 0, textRegion.w, nameH)
+      if L.showMinMaxText and not minMaxTextFits(L.minMaxBox) then
+        L.showMinMaxText = false
+      end
+      -- Compact horizontal faces retain the established distributed stack.
+      stackRows = { L.valueBox }
+      if L.showState then stackRows[#stackRows + 1] = L.stateBox end
+      if L.showMinMaxText then stackRows[#stackRows + 1] = L.minMaxBox end
+      if L.showName then stackRows[#stackRows + 1] = L.nameBox end
+      stackTop = textRegion.y
+      stackBottom = textRegion.y + textRegion.h
+    end
+  elseif orientation == "vertical" then
+    L.minMaxBox = box(textRegion.x, 0, textRegion.w, minMaxH)
+    L.nameBox = box(textRegion.x, 0, textRegion.w, nameH)
+    if L.showMinMaxText and not minMaxTextFits(L.minMaxBox) then
+      L.showMinMaxText = false
+    end
+    -- the state chip rides on the dial, not in the text column
+    L.stateBox = box(dial.x, dial.y + floor(dial.h * 0.24), dial.w, stateH)
+    stackRows = {}
+    if L.showMinMaxText then stackRows[#stackRows + 1] = L.minMaxBox end
+    if L.showName then stackRows[#stackRows + 1] = L.nameBox end
+    stackTop = L.valueBox.y + L.valueBox.h
+    stackBottom = textRegion.y + textRegion.h
+  else
+    L.stateBox = box(dial.x, dial.y + floor(dial.h * 0.26), dial.w, stateH)
+    stackTop = L.valueBox.y + L.valueBox.h
+    -- The min/max row stays TIGHT under the value, and is deliberately NOT
+    -- part of the distributed stack. It lives INSIDE the ring, where the
+    -- clear chord narrows with every pixel of descent (clipToChord below), so
+    -- "breathing room" here is bought with width: distributing it pushed the
+    -- row into a 26 px chord where "min 31" needs 36 and wrapped it to two
+    -- lines, of which one is visible. Above it the chord is widest, so tight
+    -- is also correct here - the slack belongs to the name instead.
+    L.minMaxBox = box(dial.x, stackTop + T.px(T.space.xs), dial.w, minMaxH)
+    if L.showMinMaxText then
+      clipToChord(L, L.minMaxBox)
+      if not minMaxTextFits(L.minMaxBox) then
+        L.showMinMaxText = false
+      end
+    end
+    if L.sweep >= 360 then
+      -- A CLOSED ring has no open wedge to hang the name in, so it goes
+      -- INSIDE. It used to be pinned tight under the value - 2 px below it,
+      -- with 18 px of the ring's interior left empty underneath (F3). The
+      -- reason given was G-10, "the name stays inside the ring": letting the
+      -- band run to the ring's bottom EDGE does push the name onto the arc.
+      --
+      -- But the ring's outer edge was never the right bound. The name has to
+      -- clear the arc's INNER edge, cy + clearR, which is what chordAt already
+      -- measures against - so bounding the band there distributes the slack
+      -- AND satisfies G-10 by construction rather than by staying away from
+      -- the problem. clipToChord then keeps a long source name inside the
+      -- circle at its new, lower depth, where the chord is narrower.
+      L.nameBox = box(dial.x, stackTop + T.px(T.space.xs), dial.w, nameH)
+      local ringInner = L.cy + L.radius - floor(L.trackThickness / 2)
+      stackTextRows(stackTop, ringInner - T.px(T.space.xs), { L.nameBox }, h)
+      clipToChord(L, L.nameBox)
+      L.showMinMaxText = false
+    else
+      -- The name hangs in the ring's OPEN WEDGE, below the arc's ends, so
+      -- unlike the min/max row above it, moving it down costs no width. The
+      -- old code took `closeY` - tight under the content - and left the
+      -- remainder as dead air (15 px at 260x220, Tanda 5 review 3.15 part
+      -- two). Split the difference instead: the name breathes, and `farY`
+      -- still caps it at the spot that was always known to clear the arc.
+      local afterMinMax = L.showMinMaxText
+        and (L.minMaxBox.y + L.minMaxBox.h) or stackTop
+      local closeY = afterMinMax + T.px(T.space.xs)
+      local farY = dial.y + dial.h - nameH
+      local y = closeY + floor(max(farY - closeY, 0) / 2)
+      L.nameBox = box(0, min(y, farY), w, nameH)
+    end
+    -- the balanced dial places its rows itself: inside the ring the chord,
+    -- not the slack, decides where a row may sit
+    stackRows = {}
+    stackTop, stackBottom = 0, 0
+  end
+
+  -- The unit was placed against the value's baseline inside placeValue, so if
+  -- the stack MOVED the value (it does in a horizontal zone, where the value
+  -- is one of the distributed rows) the unit has to travel with it or it is
+  -- left behind on the old baseline.
+  local valueY0 = L.valueBox.y
+  stackTextRows(stackTop, stackBottom, stackRows, h)
+  local valueDY = L.valueBox.y - valueY0
+  if valueDY ~= 0 then L.unitBox.y = L.unitBox.y + valueDY end
+  -- A row that is not drawn keeps a sane position rather than the y = 0 the
+  -- provisional boxes above carry: minMaxBox still feeds clipToChord and the
+  -- min/max split below, and a box at the top of the zone would clip against
+  -- the wrong chord.
+  if not L.showMinMaxText then
+    L.minMaxBox.y = L.valueBox.y + L.valueBox.h
+  end
+  L.textAlign = align
+  L.nameAlign = horizontalInstrument and LEFT or align
+  L.stateAlign = horizontalInstrument and RIGHT or align
+
+  -- the min/max row hangs below the value INSIDE the dial circle: constrain
+  -- it to the chord at its depth so it neither crosses the ring nor the
+  -- history marks that point into the same lower band (AUDIT.md G-7). The
+  -- minTextBox/maxTextBox split below then inherit the clipped width.
+  if orientation == "balanced" then
+    clipToChord(L, L.minMaxBox)
+  end
+
+  -- min / max text share the min-max row, LEFT and RIGHT aligned inside their
+  -- halves. That is what makes them a PAIR - so the row must be no wider than
+  -- the pair needs (F4).
+  --
+  -- It used to inherit the full width of whatever contained it. In a 480x272
+  -- zone that is the whole 202 px text column: "min 31" flush left, "max 78"
+  -- flush right, 202 px of nothing between them, with the source name starting
+  -- under "min". Three labels scattered along a line read as three unrelated
+  -- labels, not as one caption belonging to the value above.
+  --
+  -- Capped to what the two strings need plus one comfortable gap, and then
+  -- aligned the way the rest of the column is - so the group hangs together
+  -- and still never grows past the space it was given.
+  local mmNeed = T.textWidth("min " .. F.widestSample(widget), L.minMaxFont) * 2
+    + T.px(T.space.lg)
+  local mmW = min(L.minMaxBox.w, max(mmNeed, T.px(24)))
+  local mmAlign = horizontalInstrument and CENTER or align
+  if mmW < L.minMaxBox.w then
+    if mmAlign == CENTER then
+      L.minMaxBox.x = L.minMaxBox.x + floor((L.minMaxBox.w - mmW) / 2)
+    end
+    L.minMaxBox.w = mmW
+  end
+  local halfW = floor(L.minMaxBox.w / 2)
+  L.minTextBox = box(L.minMaxBox.x, L.minMaxBox.y, halfW, minMaxH)
+  L.maxTextBox = box(L.minMaxBox.x + halfW, L.minMaxBox.y, halfW, minMaxH)
+
+  -- scale end labels, one at each arc end, sitting just OUTSIDE the end
+  -- ticks. The old code centred a fixed 30 px box on the point at
+  -- tickOuter + px(sm): its inner half retreated over the end tick ("100"
+  -- read as "f00", AUDIT.md G-8), and the fixed width clipped long strings
+  -- like 20000.00 (AUDIT.md G-9). Each label is now sized with its own text
+  -- width and pushed outward along the radial until its NEAREST corner sits
+  -- at r0 - so every point of the box is at distance >= r0 from the centre,
+  -- and no point of the tick (which ends inside r0) can touch it.
+  if L.showScale then
+    local sh = T.fontHeight(L.scaleFont)
+    local r0 = L.tickOuter + T.px(T.space.sm)
+    local function placeScaleLabel(angle, text)
+      local sw = T.textWidth(text, L.scaleFont)
+      local a, b = sw / 2, sh / 2
+      local ux, uy = G.pointOnCircle(0, 0, 1, angle)
+      local sx = (ux >= 0) and a or -a
+      local sy = (uy >= 0) and b or -b
+      local dot = ux * sx + uy * sy
+      local r = dot + math.sqrt(math.max(dot * dot + r0 * r0 - a * a - b * b, 0))
+      local cx, cy = G.pointOnCircle(L.cx, L.cy, r, angle)
+      return box(cx - a, cy - b, sw, sh)
+    end
+    -- A label that the zone edge forced back over its own end tick slides
+    -- along the TANGENT until it clears the tick: the radial placement above
+    -- clears it by construction, only the zone clamp can pull it back in. A
+    -- 180 deg arc ends at 9/3 o'clock, right at the extreme marks, so on a
+    -- zone just wide enough for the dial the clamp does exactly that
+    -- (AUDIT.md G-11).
+    local function clearEndTick(angle, b)
+      local ux, uy = G.pointOnCircle(0, 0, 1, angle)
+      local px, py = -uy, ux            -- tangent unit vector
+      local halfTh = max(1, L.tickThickness / 2)
+      local tMin, tMax, pMin, pMax = math.huge, -math.huge, math.huge, -math.huge
+      for i = 1, 4 do
+        local cx0 = b.x + ((i % 2 == 1) and 0 or b.w)
+        local cy0 = b.y + (i <= 2 and 0 or b.h)
+        local dx, dy = cx0 - L.cx, cy0 - L.cy
+        local t = dx * ux + dy * uy
+        local pt = dx * px + dy * py
+        if t < tMin then tMin = t end
+        if t > tMax then tMax = t end
+        if pt < pMin then pMin = pt end
+        if pt > pMax then pMax = pt end
+      end
+      -- clear when the radial span or the perpendicular band misses the tick
+      if tMax <= L.tickInner or tMin >= L.tickOuter
+        or pMax <= -halfTh or pMin >= halfTh then
+        return b
+      end
+      local gap = 1
+      local function shifted(s)
+        return box(b.x + px * s, b.y + py * s, b.w, b.h)
+      end
+      local function inZone(bb)
+        return bb.x >= 0 and bb.y >= 0
+          and bb.x + bb.w <= w and bb.y + bb.h <= h
+      end
+      local d = shifted(halfTh + gap - pMin)          -- slide along +tangent
+      if inZone(d) then return d end
+      local u = shifted(-halfTh - gap - pMax)         -- or along -tangent
+      if inZone(u) then return u end
+      return b  -- no room either way: keep the clamped position
+    end
+    L.scaleMinBox = placeScaleLabel(L.startAngle,
+      F.display(widget, widget.config.min))
+    L.scaleMaxBox = placeScaleLabel(L.startAngle + L.sweep,
+      F.display(widget, widget.config.max))
+    -- do not let the labels leave the zone
+    if L.scaleMinBox.x < 0 then L.scaleMinBox.x = 0 end
+    if L.scaleMaxBox.x + L.scaleMaxBox.w > w then
+      L.scaleMaxBox.x = w - L.scaleMaxBox.w
+    end
+    L.scaleMinBox = clearEndTick(L.startAngle, L.scaleMinBox)
+    L.scaleMaxBox = clearEndTick(L.startAngle + L.sweep, L.scaleMaxBox)
+    -- Endpoint labels are atomic: showing only one implies a false range. A
+    -- normal horizontal face may use them only when both boxes remain inside
+    -- the zone, remain distinct, and stay out of the information column.
+    local function inside(bb)
+      return bb.x >= 0 and bb.y >= 0
+        and bb.x + bb.w <= w and bb.y + bb.h <= h
+    end
+    local function intersects(a, b)
+      return a.x < b.x + b.w and a.x + a.w > b.x
+        and a.y < b.y + b.h and a.y + a.h > b.y
+    end
+    if not inside(L.scaleMinBox) or not inside(L.scaleMaxBox)
+      or intersects(L.scaleMinBox, L.scaleMaxBox)
+      or (horizontalInstrument
+          and (intersects(L.scaleMinBox, textRegion)
+               or intersects(L.scaleMaxBox, textRegion))) then
+      L.showScale = false
+    end
+  end
+
+  -- C1 (Tanda 7): centre the whole composition in a VERTICAL zone.
+  --
+  -- The dial is pinned to the top with `pad`, and its side is capped at
+  -- min(w, h * 0.62) - so in a tall, narrow zone the dial is width-limited and
+  -- cannot grow, the text is centred in whatever is left, and the result is
+  -- air at both ends. Measured at 100x260: the dial ended at y=94, the value
+  -- sat at 164..188, leaving 70 px above it and 72 px below - 142 of 260 px,
+  -- 55 % of the zone, unused.
+  --
+  -- Shifting dial and text down together as one group closes that. The shift
+  -- is capped by the CONTAINMENT budget rather than applied blindly: moving
+  -- the ring down reduces its clearance to the bottom edge, and the ring's
+  -- outermost line geometry must stay inside the zone or the widget dies on
+  -- luaL_checkunsigned (see the edgeReach clamp above, and R-1/R-4).
+  if orientation == "vertical" then
+    local top = min(L.cy - L.tickOuter, L.valueBox.y)
+    local bottom = max(L.cy + L.tickOuter, L.valueBox.y + L.valueBox.h)
+    if L.showMinMaxText then bottom = max(bottom, L.minMaxBox.y + L.minMaxBox.h) end
+    if L.showName then bottom = max(bottom, L.nameBox.y + L.nameBox.h) end
+    local shift = floor(((h - (bottom - top)) / 2) - top)
+    -- never move UP (that would undo the top padding), and never eat into the
+    -- clearance the ring needs below itself
+    local room = (h - L.cy) - max(L.tickOuter, L.markOuter) - 1
+    shift = min(shift, max(room, 0))
+    -- And never push the composition PAST the bottom edge. When the content
+    -- is taller than the zone - a 16x22 micro dial, where neither the ring
+    -- nor the smallest font can shrink any further - the group already
+    -- overflows at the top, and centring it just moves the overflow to the
+    -- bottom, where it takes the value label out of the zone with it.
+    shift = min(shift, max(h - bottom, 0))
+    if shift > 0 then
+      L.cy = L.cy + shift
+      local boxes = { L.valueBox, L.unitBox, L.minMaxBox, L.nameBox,
+                      L.stateBox, L.minTextBox, L.maxTextBox,
+                      L.scaleMinBox, L.scaleMaxBox }
+      for i = 1, #boxes do
+        if boxes[i] then boxes[i].y = boxes[i].y + shift end
+      end
+    end
+  end
+end
+
+
+function M.calculate(widget, cfg, L)
+  local w, h = widget.zone.w, widget.zone.h
+  if not L then
+    local mode, orientation = C.classify(w, h)
+    L = { mode = mode, orientation = orientation, w = w, h = h }
+  end
+  L.style = "dial"
+  dialLayout(widget, cfg, L, w, h)
+  return L
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/dial_renderer.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/dial_renderer.lua
@@ -1,0 +1,731 @@
+---- #########################################################################
+---- # Gauge Core - retained LVGL dial renderer                              #
+---- #########################################################################
+
+local M = {}
+local floor, max, min = math.floor, math.max, math.min
+local T, G, F, U
+local setProp, label, resolveColor, stateText
+
+-- Object budget for the spatial gradient's arc slices. The dial's worst-case
+-- tree (needle + hub + ticks + rails + history + full text stack) sits around
+-- 30 objects, and the whole-tree ceiling both families are held to is 38, so
+-- the ramp gets what is left with a floor that still reads as a ramp.
+local DIAL_GRADIENT_SLICES = 8
+
+function M.setup(uiCore, theme, geometry, format)
+  U, T, G, F = uiCore, theme, geometry, format
+  setProp, label, resolveColor = U.setProp, U.label, U.resolveColor
+  stateText = U.stateText
+  M.updateSourceLabels = U.updateSourceLabels
+end
+
+local function markRoundCenter(widget, obj)
+  local ui = widget.ui
+  local round = ui.roundCenters
+  if not round then
+    round = {}
+    ui.roundCenters = round
+  end
+  round[obj] = true
+end
+
+-- ---------------------------------------------------------------- angles --
+
+local function angleOf(widget, value)
+  local cfg, L = widget.config, widget.layout
+  local a = G.valueToAngle(value, cfg.min, cfg.max, L.startAngle, L.sweep)
+  a = floor(a + 0.5)
+  -- a full ring must never close onto its own start angle (zero length arc)
+  local limit = L.startAngle + L.sweep - ((L.sweep >= 360) and 1 or 0)
+  if a > limit then a = limit end
+  if a < L.startAngle then a = L.startAngle end
+  return a
+end
+M.angleOf = angleOf
+
+-- Ordered (lo, hi) angle span for a band. Bands are always ascending in
+-- VALUE space (ranges.build), but a descending scale (Min > Max) mirrors the
+-- value->angle mapping (geometry.normalize), so angleOf(r.from) can come out
+-- above angleOf(r.to). Sorting here, rather than assuming a2 > a1, is what
+-- keeps sections/rails/marks visible on a descending scale (AUDIT.md P0-3).
+local function bandSpan(widget, r)
+  local a1, a2 = angleOf(widget, r.from), angleOf(widget, r.to)
+  if a1 > a2 then a1, a2 = a2, a1 end
+  return a1, a2
+end
+M.bandSpan = bandSpan
+
+-- ----------------------------------------------------------------- build --
+
+local function buildTrack(widget)
+  local ui, L, cfg = widget.ui, widget.layout, widget.config
+  -- Same clamp as angleOf(): lv_arc_set_bg_end_angle only subtracts 360 once
+  -- (270 + 360 = 630 -> 270, equal to bgStartAngle), and LVGL skips drawing a
+  -- zero-length arc entirely, so a full ring's background track never
+  -- rendered without this (AUDIT.md P0-4).
+  local endA = L.startAngle + L.sweep - ((L.sweep >= 360) and 1 or 0)
+  ui.track = lvgl.arc{
+    x = L.cx, y = L.cy, radius = L.radius,
+    startAngle = L.startAngle, endAngle = endA,
+    bgStartAngle = L.startAngle, bgEndAngle = endA,
+    color = T.color.rail, bgColor = T.color.rail,
+    bgOpacity = T.opacity.rail, opacity = 0,
+    thickness = L.trackThickness, rounded = 1,
+  }
+
+  -- Sections: the whole scale as three coloured bands on the OUTER ring -
+  -- the same position/opacity model as the Rail mode below - so the bands
+  -- stay clearly visible regardless of where the value arc currently sits.
+  -- Drawing them at the value arc's own radius/thickness put them directly
+  -- underneath it at 25% opacity, which made Sections pixel-identical to
+  -- Static at any value inside the normal band (AUDIT.md G-2).
+  if cfg.colorMode == U.COLOR_SECTIONS then
+    ui.sections = {}
+    ui.sectionRoles = {}
+    for i = 1, #widget.ranges do
+      local r = widget.ranges[i]
+      local a1, a2 = bandSpan(widget, r)
+      if a2 > a1 then
+        local c = T.stateColor(r.role, widget.accent)
+        local sec = lvgl.arc{
+          x = L.cx, y = L.cy, radius = L.railRadius,
+          startAngle = a1, endAngle = a2,
+          bgStartAngle = a1, bgEndAngle = a2,
+          color = c, bgColor = c, bgOpacity = 255, opacity = 0,
+          thickness = L.railThickness, rounded = 0,
+        }
+        -- LVGL objects are opaque userdata on the radio (no __newindex), so
+        -- the role the repaint path needs rides in a parallel array instead
+        -- of on the object (degenerate bands are skipped at build, so
+        -- sections[i] is not ranges[i]).
+        ui.sections[#ui.sections + 1] = sec
+        ui.sectionRoles[#ui.sections] = r.role
+        markRoundCenter(widget, sec)
+      end
+    end
+  end
+
+  -- threshold rail: a thin permanent reminder of where the bands are, drawn
+  -- outside the track so the value arc keeps the foreground to itself. The
+  -- bands draw at reduced opacity (railBand) so they read as the reference
+  -- behind the value arc: in a critical state, the red of the arc dominates
+  -- the red of the band instead of merging into one bevelled blob
+  -- (review P-E).
+  if cfg.colorMode == U.COLOR_RAIL then
+    ui.rails = {}
+    for i = 1, #widget.ranges do
+      local r = widget.ranges[i]
+      if r.role ~= "normal" then
+        local a1, a2 = bandSpan(widget, r)
+        if a2 > a1 then
+          local c = T.stateColor(r.role, widget.accent)
+          local rail = lvgl.arc{
+            x = L.cx, y = L.cy, radius = L.railRadius,
+            startAngle = a1, endAngle = a2,
+            bgStartAngle = a1, bgEndAngle = a2,
+            color = c, bgColor = c, bgOpacity = T.opacity.railBand, opacity = 0,
+            thickness = L.railThickness, rounded = 0,
+          }
+          ui.rails[#ui.rails + 1] = rail
+          markRoundCenter(widget, rail)
+        end
+      end
+    end
+  end
+end
+
+local function buildTicks(widget)
+  local ui, L = widget.ui, widget.layout
+  ui.ticks = {}
+  local count = L.tickCount
+  for i = 1, count do
+    local a = L.startAngle + ((i - 1) / (count - 1)) * L.sweep
+    ui.ticks[i] = lvgl.line{
+      pts = G.linePoints(L.cx, L.cy, L.tickInner, L.tickOuter, a),
+      thickness = L.tickThickness, color = T.color.tick,
+    }
+  end
+  -- Minor ticks are shorter, thinner and dimmer rather than dashed:
+  -- dashGap/dashWidth exist on hline/vline only (LvglWidgetLineBase), not on
+  -- the free-angle line class (LvglWidgetLine).
+  if L.minorTicks and L.minorTicks > 0 then
+    ui.minors = {}
+    local inner = L.tickInner
+    local outer = L.tickInner + floor((L.tickOuter - L.tickInner) * 0.55)
+    for i = 1, L.minorTicks do
+      local a = L.startAngle + ((i - 0.5) / (count - 1)) * L.sweep
+      ui.minors[i] = lvgl.line{
+        pts = G.linePoints(L.cx, L.cy, inner, outer, a),
+        thickness = 1, color = T.color.tick, opacity = T.opacity.ghost,
+      }
+    end
+  end
+end
+
+-- Threshold mode's contract is "exact marks", and the bar has always drawn
+-- them. The dial drew nothing, so Static, Threshold and Gradient were
+-- byte-identical for as long as the reading stayed in the normal band - which
+-- is nearly all of it. One radial line per INTERIOR boundary, in that
+-- boundary's own colour, spanning the track so it reads against the arc
+-- whether the arc has reached it or not.
+local function buildThresholdMarks(widget)
+  local ui, L, cfg = widget.ui, widget.layout, widget.config
+  ui.thresholdMarks = {}
+  for i = 1, #widget.ranges do
+    local r = widget.ranges[i]
+    local t = G.normalize(r.to, cfg.min, cfg.max)
+    -- Interior only: the two ends of the scale are the track's own edges.
+    if t > 0 and t < 1 then
+      local a = angleOf(widget, r.to)
+      ui.thresholdMarks[#ui.thresholdMarks + 1] = lvgl.line{
+        pts = G.linePoints(L.cx, L.cy, L.thresholdInner, L.thresholdOuter, a),
+        thickness = L.thresholdThickness,
+        color = T.stateColor(r.role, widget.accent),
+      }
+    end
+  end
+end
+
+local function buildNeedle(widget)
+  local ui, L = widget.ui, widget.layout
+  local a = L.startAngle
+  -- A needle of LINES, not triangles: on the radio LvglWidgetTriangle::refresh
+  -- frees the canvas and rebuilds it on every angle change - under needle
+  -- damping the smoothed value moves almost every frame, so the audit
+  -- measured ~46 canvas rebuilds in 20 frames and ~24 KB of heap churn per
+  -- frame on a 200x200 zone (AUDIT.md P2-1). LvglWidgetLine::refresh only
+  -- rewrites the points: no allocation churn at all.
+  --
+  -- The taper lost by P2-1 is restored with three lines, not two (review
+  -- P-A, revised Tanda 5 on owner feedback): base -> mid -> tip. Two steps
+  -- (thick body straight to a 2 px tip) read as a paddle with a toothpick
+  -- glued to the end - the width more than halved in one jump. A middle
+  -- segment splits that into two smaller steps, and `rounded = 1` on all
+  -- three softens both the hub end and the two seams so they blend instead
+  -- of showing a hard edge.
+  -- Fixed colour, set once here and never touched by applyColors: the
+  -- needle must stay legible against every band colour (green/amber/red)
+  -- and the dark/light theme alike, so it does not follow the state colour
+  -- the way the arc and value do (owner request, Tanda 5 review).
+  -- The pts BUFFERS are persistent per segment (Phase 5.1): the binding
+  -- copies the coordinates out on every set and keeps no reference, so
+  -- updateArc can mutate them in place - the needle no longer allocates
+  -- nine tables per angle change (Tanda 6 F-11). The { pts = ... } WRAPPER
+  -- passed to lvgl.set is hoisted to a per-segment persistent table too
+  -- (Phase 5.2): luaLvglSet parses the params table at CALL TIME
+  -- (getParams -> parseParam, api_colorlcd_lvgl.cpp:116, lua_lvgl_widget.cpp
+  -- :763) and retains no reference, so the same wrapper can be passed
+  -- forever - its pts field points at the persistent buffer, whose fresh
+  -- contents are read on every set. Both buffers and wrappers must NEVER
+  -- go through setProp: its cache compares tables by identity and would
+  -- drop every write after the first (5.1/5.2 TRAP 2) - the needle stays
+  -- on direct lvgl.set.
+  ui.needlePts = { { 0, 0 }, { 0, 0 } }
+  ui.needleMidPts = { { 0, 0 }, { 0, 0 } }
+  ui.needleTipPts = { { 0, 0 }, { 0, 0 } }
+  ui.needleSet = { pts = ui.needlePts }
+  ui.needleMidSet = { pts = ui.needleMidPts }
+  ui.needleTipSet = { pts = ui.needleTipPts }
+  ui.needle = lvgl.line{
+    pts = G.linePointsInto(ui.needlePts, L.cx, L.cy, L.needleInner,
+                           L.needleBodyOuter, a),
+    thickness = max(1, L.needleHalf * 2), rounded = 1, color = T.color.needle,
+  }
+  ui.needleMid = lvgl.line{
+    pts = G.linePointsInto(ui.needleMidPts, L.cx, L.cy, L.needleMidInner,
+                           L.needleMidOuter, a),
+    thickness = max(1, L.needleMidHalf * 2), rounded = 1, color = T.color.needle,
+  }
+  ui.needleTip = lvgl.line{
+    pts = G.linePointsInto(ui.needleTipPts, L.cx, L.cy, L.needleTipInner,
+                           L.needleOuter, a),
+    thickness = L.needleTipThickness, rounded = 1, color = T.color.needle,
+  }
+  -- Solid hub: ONE filled circle in the neutral rail role, created after the
+  -- needle so it covers the blade's inner end. The old ring+accent-dot pair
+  -- read as pixel noise where needle, value and pivot meet; a clean solid
+  -- circle reads as a deliberate centre (review P-A). The hub keeps the
+  -- neutral tone in every state - it is the pivot, not a state indicator.
+  ui.pivotRing = lvgl.circle{
+    x = L.cx, y = L.cy, radius = L.pivotRadius,
+    filled = 1, color = T.color.rail,
+  }
+end
+
+function M.build(widget)
+  local L, ui = widget.layout, widget.ui
+
+  buildTrack(widget)
+  buildTicks(widget)
+
+  if L.showGhost then
+    ui.ghost = lvgl.arc{
+      x = L.cx, y = L.cy, radius = L.radius,
+      startAngle = L.startAngle, endAngle = L.startAngle,
+      bgStartAngle = L.startAngle, bgEndAngle = L.startAngle,
+      bgOpacity = 0, opacity = T.opacity.ghost,
+      color = T.color.rail,
+      thickness = L.ghostThickness, rounded = 1,
+    }
+    lvgl.hide(ui.ghost)
+    markRoundCenter(widget, ui.ghost)
+  end
+
+  -- Gradient is SPATIAL on both families (ui_core, "spatial gradient"): the
+  -- arc is cut into slices whose colour is the severity of that point on the
+  -- scale, exactly as the bar cuts its axis. The dial used to paint the whole
+  -- arc one colour derived from the CURRENT value instead, which made Static,
+  -- Threshold and Gradient byte-identical in the normal state and gave one
+  -- option name two meanings across two widgets on the same screen.
+  if widget.config.colorMode == U.COLOR_GRADIENT then
+    local count = U.gradientSliceCount(
+      L.radius * L.sweep * 0.0175, DIAL_GRADIENT_SLICES)
+    ui.gradientArcs = {}
+    ui.gradientSpans = {}
+    local cfg = widget.config
+    for i = 1, count do
+      local a1 = L.startAngle + L.sweep * (i - 1) / count
+      local a2 = L.startAngle + L.sweep * i / count
+      local arc = lvgl.arc{
+        x = L.cx, y = L.cy, radius = L.radius,
+        startAngle = a1, endAngle = a2,
+        bgStartAngle = a1, bgEndAngle = a2,
+        bgOpacity = 0,
+        color = U.spatialColor(cfg, nil, (i - 0.5) / count),
+        -- Butt ends inside the run: a rounded cap on every slice would bead
+        -- the arc. Only the two extremes keep the family's rounded end.
+        thickness = L.arcThickness, rounded = (count == 1) and 1 or 0,
+      }
+      lvgl.hide(arc)
+      markRoundCenter(widget, arc)
+      ui.gradientArcs[i] = arc
+      ui.gradientSpans[i] = { a1, a2, shown = false }
+    end
+    -- One canonical handle for shared code, as the bar keeps ui.fill.
+    ui.valueArc = ui.gradientArcs[1]
+  else
+    ui.valueArc = lvgl.arc{
+      x = L.cx, y = L.cy, radius = L.radius,
+      startAngle = L.startAngle, endAngle = L.startAngle,
+      bgStartAngle = L.startAngle, bgEndAngle = L.startAngle + L.sweep,
+      bgOpacity = 0, color = T.color.accent,
+      thickness = L.arcThickness, rounded = 1,
+    }
+    markRoundCenter(widget, ui.valueArc)
+  end
+
+  if widget.config.colorMode == U.COLOR_THRESHOLD then
+    buildThresholdMarks(widget)
+  end
+
+  if L.showNeedle then buildNeedle(widget) end
+
+  if L.showMarkers then
+    -- Persistent pts buffers and persistent { pts = ... } wrappers, exactly
+    -- like the needle (Phase 5.1 + 5.2): the binding copies the coordinates
+    -- out on every set and retains no reference to either table, so both can
+    -- be mutated in place forever. The marks were left out of Phase 5 and
+    -- stayed the last per-frame allocator on the dial - 870 B/frame for the
+    -- whole time the history is advancing, which is every second of a climb,
+    -- not the "few seconds after power-up" the original note assumed.
+    -- NEVER route these through setProp: its cache compares tables by
+    -- identity and would drop every write after the first (5.1/5.2 TRAP 2).
+    ui.minMarkPts = { { 0, 0 }, { 0, 0 } }
+    ui.maxMarkPts = { { 0, 0 }, { 0, 0 } }
+    ui.minMarkSet = { pts = ui.minMarkPts }
+    ui.maxMarkSet = { pts = ui.maxMarkPts }
+    ui.minMark = lvgl.line{
+      pts = G.linePointsInto(ui.minMarkPts, L.cx, L.cy, L.markInner,
+                             L.markOuter, L.startAngle),
+      thickness = max(1, L.tickThickness), color = T.color.history,
+    }
+    ui.maxMark = lvgl.line{
+      pts = G.linePointsInto(ui.maxMarkPts, L.cx, L.cy, L.markInner,
+                             L.markOuter, L.startAngle),
+      thickness = max(1, L.tickThickness), color = T.color.history,
+    }
+    lvgl.hide(ui.minMark)
+    lvgl.hide(ui.maxMark)
+  end
+
+  ui.valueLabel = label(L.valueBox, L.valueFont, T.color.accent, L.valueAlign,
+                        F.NO_VALUE)
+  if L.showUnit and widget.unitText ~= "" then
+    ui.unitLabel = label(L.unitBox, L.unitFont, T.color.label, L.unitAlign,
+                         widget.unitText)
+  end
+  if L.showName then
+    ui.nameLabel = label(L.nameBox, L.nameFont, T.color.label, L.nameAlign,
+                         widget.nameText)
+  end
+  if L.showState then
+    -- The pill is taller than the state text and centred on it, so the
+    -- letters sit in the middle of the pill, not 1 px from its top edge
+    -- (review P-B). The centring offset is LAYOUT data (L.chipOff): it must
+    -- survive a no-op update(), which replaces the layout table but only
+    -- rebuilds on a signature change - a renderer-written field was lost
+    -- and the next chip render crashed on nil (Tanda 6 F-1).
+    -- 1 px outline in the label role, behind the pill, so the badge keeps a
+    -- defined edge instead of reading as "a piece of the rail behind the
+    -- text" (review P-B). It matters more now that the fill is a status
+    -- colour: the outline is what separates the badge from a theme whose
+    -- background happens to sit near the same luminance, or from a
+    -- background.png photograph.
+    local edge = L.chipOutline
+    ui.chipEdge = lvgl.rectangle{
+      x = L.stateBox.x - edge, y = L.stateBox.y - L.chipOff - edge,
+      w = L.stateBox.w + edge * 2, h = L.chipHeight + edge * 2,
+      color = T.color.label, filled = 1,
+      rounded = floor((L.chipHeight + edge * 2) / 2),
+    }
+    -- Built muted, shown coloured: the badge is hidden here and updateChip
+    -- sets its fill and its ink from the state before it is ever shown.
+    ui.chip = lvgl.rectangle{
+      x = L.stateBox.x, y = L.stateBox.y - L.chipOff,
+      w = L.stateBox.w, h = L.chipHeight,
+      color = T.color.muted, filled = 1, rounded = floor(L.chipHeight / 2),
+    }
+    lvgl.hide(ui.chipEdge)
+    lvgl.hide(ui.chip)
+    -- hidden at build like the pill it belongs to: the three are one object
+    -- as far as visibility is concerned (see updateChip)
+    ui.stateLabel = label(L.stateBox, L.stateFont, T.labelOn(T.color.muted),
+                          L.stateAlign)
+    lvgl.hide(ui.stateLabel)
+  end
+  if L.showMinMaxText then
+    ui.minText = label(L.minTextBox, L.minMaxFont, T.color.history, LEFT)
+    ui.maxText = label(L.maxTextBox, L.minMaxFont, T.color.history, RIGHT)
+  end
+  if L.showScale then
+    ui.scaleMin = label(L.scaleMinBox, L.scaleFont, T.color.label, CENTER,
+                        F.display(widget, widget.config.min))
+    ui.scaleMax = label(L.scaleMaxBox, L.scaleFont, T.color.label, CENTER,
+                        F.display(widget, widget.config.max))
+  end
+
+  widget.frame = {
+    props = {},
+    dirty = {},
+    angle = -1, ghostAngle = -1, minAngle = -1, maxAngle = -1,
+    needleShown = true, markersShown = false, chipShown = false,
+    colorKey = "", accentKey = nil, valueStr = "", stateStr = "",
+    minStr = "", maxStr = "",
+    prevAvail = "unset", pulse = false, pulseAt = 0,
+  }
+  ui.built = true
+end
+
+local function applyColors(widget, key)
+  local ui = widget.ui
+  local c = resolveColor(widget, key)
+  local opa = (key == "muted") and T.opacity.muted or T.opacity.full
+  if ui.gradientArcs then
+    -- Each slice owns its colour (the severity of its own position), so only
+    -- the muted/live opacity is a per-state decision here.
+    for i = 1, #ui.gradientArcs do
+      setProp(widget, ui.gradientArcs[i], "opacity", opa)
+    end
+  else
+    setProp(widget, ui.valueArc, "color", c)
+    setProp(widget, ui.valueArc, "opacity", opa)
+  end
+  -- the VALUE's ink is not set here: it follows the state, which moves on its
+  -- own gate (U.applyStateInk)
+  -- the needle is intentionally NOT touched here: it keeps T.color.needle,
+  -- set once at build time (buildNeedle)
+  --
+  -- Neither is the badge: its fill and label are set by updateChip, which runs
+  -- on a change of the state STRING. That is the correct gate - in Static mode
+  -- colorKey never leaves "static", so a normal -> warning transition does not
+  -- reach this function at all, and a badge coloured from here would have kept
+  -- saying WARN in the all-clear colour.
+  if ui.sections then
+    -- The NORMAL band carries the accent and was painted at build time; an
+    -- Accent edit repaints here without a rebuild, so it must be recolored
+    -- in place (Tanda 6 F-5). The warn/crit bands are fixed colours and
+    -- resolve to the same colour as before - setProp filters the no-ops.
+    for i = 1, #ui.sections do
+      local sec = ui.sections[i]
+      setProp(widget, sec, "color",
+              T.stateColor(ui.sectionRoles[i], widget.accent))
+      -- F2: the reference bands used to keep full opacity while the gauge
+      -- itself was muted, so a widget announcing NO LINK still had three
+      -- fully saturated bands on it - one of them red - and they were the
+      -- brightest thing on the dial. Whatever the value arc does, the passive
+      -- reference behind it does too.
+      setProp(widget, sec, "bgOpacity", opa)
+    end
+  end
+  if ui.rails then
+    -- P1-3 (Tanda 5 review 3.6): only while critical, drop every passive
+    -- band one step further so the full-red arc/text stay the brightest
+    -- thing on the ring. WARN keeps the normal reference opacity - there
+    -- the amber band IS the active state, not a competing one.
+    -- Muted overrides both: see the note on sections above.
+    local railOpa = T.opacity.railBand
+    if key == "muted" then railOpa = T.opacity.muted
+    elseif key == "critical" then railOpa = T.opacity.railBandCrit end
+    for _, rail in ipairs(ui.rails) do
+      setProp(widget, rail, "bgOpacity", railOpa)
+    end
+  end
+end
+local function updateText(widget)
+  local ui, frame = widget.ui, widget.frame
+  local data = widget.data
+
+  local str
+  if data.availability == "unset" then
+    str = F.NO_VALUE
+  else
+    str = F.display(widget, data.displayValue)
+  end
+  if str ~= frame.valueStr then
+    frame.valueStr = str
+    setProp(widget, ui.valueLabel, "text", str)
+    U.anchorUnit(widget, str)
+  end
+
+  if ui.stateLabel then
+    local s = stateText(widget)
+    if s ~= frame.stateStr then
+      frame.stateStr = s
+      setProp(widget, ui.stateLabel, "text", s)
+      U.updateChip(widget, s)
+    end
+  end
+
+  if ui.minText then
+    local h = widget.history
+    local mn = h.min and F.display(widget, h.min) or ""
+    local mx = h.max and F.display(widget, h.max) or ""
+    if mn ~= frame.minStr then
+      frame.minStr = mn
+      setProp(widget, ui.minText, "text", (mn ~= "") and ("min " .. mn) or "")
+    end
+    if mx ~= frame.maxStr then
+      frame.maxStr = mx
+      setProp(widget, ui.maxText, "text", (mx ~= "") and ("max " .. mx) or "")
+    end
+  end
+end
+
+-- NEEDLE LENGTH IS CONSTANT (Tanda 7 A, replacing Tanda 5 review 3.12/P0-4).
+--
+-- P0-4 used to shorten the blade whenever the current angle's ray entered the
+-- state chip, so it would not be "drawn through a solid pill". The paint
+-- order already guarantees that: renderer.build creates the needle (objects
+-- 11-13 on a 200x160 dial) BEFORE the chip (20-21), the chip is `filled = 1`
+-- with no opacity - fully opaque - and LVGL paints children in creation
+-- order. The blade behind the pill was never visible in the first place.
+--
+-- What the truncation did cost was the needle itself. Measured at 200x160,
+-- Sweep 270, chip shown: 41 % of the blade left at value 30, 28 % at 34,
+-- 18 % at 40, and 13 % - 5 of 38 px - at value 50. It bit on 25 % of the
+-- scale at 270 deg, 35 % at 180 and 16 % at 360, and ONLY while a chip was
+-- up: that is WARN / CRIT / STALE / NO LINK / NO DATA, the states the pilot
+-- actually looks at. A needle that changes length as it sweeps reads as a
+-- rendering fault, because no real instrument does it.
+--
+-- So the needle now runs its full reach at every angle and passes BEHIND the
+-- badge, the way a pointer passes behind a label on a real gauge. This is the
+-- same creation-order contract the value and name labels already rely on to
+-- paint over the arcs (Tanda 5 review 3.1) - not a new assumption. It is
+-- pinned by "A: the chip occludes the needle by paint order" in the suite, so
+-- if the order or the chip's opacity ever changes, that test fails first and
+-- says why.
+
+-- Sweep the sliced ramp up to `angle`. Only the slice the value is inside
+-- changes span; the ones behind it are already at full span and the ones
+-- ahead are already hidden, so an ordinary frame touches one object - the
+-- same shape as the bar's gradient prefix walk.
+local function updateGradientArcs(widget, angle)
+  local ui = widget.ui
+  local arcs, spans = ui.gradientArcs, ui.gradientSpans
+  for i = 1, #arcs do
+    local span = spans[i]
+    local a1, a2 = span[1], span[2]
+    if angle >= a2 then
+      if span.paint ~= a2 then
+        span.paint = a2
+        setProp(widget, arcs[i], "endAngle", a2)
+      end
+      if not span.shown then
+        span.shown = true
+        lvgl.show(arcs[i])
+      end
+    elseif angle > a1 then
+      local clipped = min(a2, max(a1, angle))
+      if span.paint ~= clipped then
+        span.paint = clipped
+        setProp(widget, arcs[i], "endAngle", clipped)
+      end
+      if not span.shown then
+        span.shown = true
+        lvgl.show(arcs[i])
+      end
+    elseif span.shown then
+      span.shown = false
+      lvgl.hide(arcs[i])
+    end
+  end
+end
+
+local function updateArc(widget)
+  local ui, L, frame = widget.ui, widget.layout, widget.frame
+  local data = widget.data
+
+  if data.availability ~= "valid" or data.displayValue == nil then
+    widget.smooth.value = nil
+    if frame.needleShown then
+      frame.needleShown = false
+      if ui.needle then lvgl.hide(ui.needle) end
+      if ui.needleMid then lvgl.hide(ui.needleMid) end
+      if ui.needleTip then lvgl.hide(ui.needleTip) end
+    end
+    return
+  end
+
+  if frame.prevAvail ~= "valid" then
+    widget.smooth.value = nil  -- snap on reconnect instead of sweeping up
+  end
+  local sv = widget.mods.smoothing.step(widget, data.displayValue)
+  local a = angleOf(widget, sv)
+  -- The old `or frame.chipShown ~= frame.needleClampChip` term went with
+  -- needleReach: it existed only to re-cut the blade when the chip appeared
+  -- or vanished, and a blade of constant length has nothing to re-cut. One
+  -- fewer comparison per frame, and one fewer needle rewrite per state change.
+  if a ~= frame.angle then
+    frame.angle = a
+    if ui.gradientArcs then
+      updateGradientArcs(widget, a)
+    else
+      setProp(widget, ui.valueArc, "endAngle", a)
+    end
+    if ui.needle then
+      -- three line segments, all rewritten with the same guarded pts path
+      -- as before: base + mid + tip sweep together (P2-1). The pts tables
+      -- are the PERSISTENT buffers from buildNeedle, mutated in place by
+      -- linePointsInto, and the wrappers are the PERSISTENT { pts = ... }
+      -- tables too - zero allocation per frame (Phase 5.1 + 5.2). Direct
+      -- lvgl.set, NEVER setProp (identity cache would freeze both, TRAP 2).
+      G.linePointsInto(ui.needlePts, L.cx, L.cy, L.needleInner,
+                       L.needleBodyOuter, a)
+      lvgl.set(ui.needle, ui.needleSet)
+      G.linePointsInto(ui.needleMidPts, L.cx, L.cy, L.needleMidInner,
+                       L.needleMidOuter, a)
+      lvgl.set(ui.needleMid, ui.needleMidSet)
+      G.linePointsInto(ui.needleTipPts, L.cx, L.cy, L.needleTipInner,
+                       L.needleOuter, a)
+      lvgl.set(ui.needleTip, ui.needleTipSet)
+    end
+  end
+  if not frame.needleShown then
+    frame.needleShown = true
+    if ui.needle then lvgl.show(ui.needle) end
+    if ui.needleMid then lvgl.show(ui.needleMid) end
+    if ui.needleTip then lvgl.show(ui.needleTip) end
+  end
+end
+
+local function updateHistory(widget)
+  local ui, L, frame = widget.ui, widget.layout, widget.frame
+  local h = widget.history
+
+  -- peak-hold ghost: INDEPENDENT of the markers option (firmware idiom
+  -- C.3 - always created, visibility driven by DATA). The dial used to
+  -- early-return on ui.minMark, so with Min/max = Off the ghost existed
+  -- but could never show, while the bar's ghost worked (Tanda 6 F-8).
+  -- Both h.min and h.max are required: readHistorySiblings can populate
+  -- them independently, and the descending-scale peak picks either one.
+  if ui.ghost then
+    if h.min and h.max then
+      local peak = (widget.config.max >= widget.config.min) and h.max or h.min
+      local ga = angleOf(widget, peak)
+      if ga ~= frame.ghostAngle then
+        frame.ghostAngle = ga
+        setProp(widget, ui.ghost, "endAngle", ga)
+        setProp(widget, ui.ghost, "bgEndAngle", ga)
+        lvgl.show(ui.ghost)
+      end
+    elseif frame.ghostAngle ~= -1 then
+      -- The history was CLEARED - the reset switch, a source change, a range
+      -- edit. The markers below already leave on the same event; the ghost
+      -- used to stay behind, still marking a peak that no longer exists, and
+      -- only corrected itself on the next valid reading. In a dropout, or
+      -- straight after a reset on a disconnected model, that is indefinite.
+      -- -1 is the build-time sentinel and no real angle (angleOf never
+      -- returns below startAngle), so restoring it also re-arms the show.
+      frame.ghostAngle = -1
+      lvgl.hide(ui.ghost)
+    end
+  end
+
+  if not ui.minMark then return end
+
+  local shown = (h.min ~= nil and h.max ~= nil)
+  if shown ~= frame.markersShown then
+    frame.markersShown = shown
+    if shown then
+      lvgl.show(ui.minMark)
+      lvgl.show(ui.maxMark)
+    else
+      lvgl.hide(ui.minMark)
+      lvgl.hide(ui.maxMark)
+    end
+  end
+  if not shown then return end
+
+  -- in-place into the build-time buffers, direct lvgl.set, never setProp
+  local a = angleOf(widget, h.min)
+  if a ~= frame.minAngle then
+    frame.minAngle = a
+    G.linePointsInto(ui.minMarkPts, L.cx, L.cy, L.markInner, L.markOuter, a)
+    lvgl.set(ui.minMark, ui.minMarkSet)
+  end
+  a = angleOf(widget, h.max)
+  if a ~= frame.maxAngle then
+    frame.maxAngle = a
+    G.linePointsInto(ui.maxMarkPts, L.cx, L.cy, L.markInner, L.markOuter, a)
+    lvgl.set(ui.maxMark, ui.maxMarkSet)
+  end
+end
+function M.update(widget)
+  local ui = widget.ui
+  if not ui.built then return end
+  local frame = widget.frame
+
+  local key = U.colorKey(widget)
+  -- The accent is an INPUT to the colour (normal band, Static mode), so an
+  -- Accent edit must repaint even when the semantic key did not change
+  -- (Tanda 6 F-5; cf. radio_info.cpp re-reading its colour options in
+  -- update()). frame.colorKey stays the SEMANTIC key - tests and the
+  -- gallery read it as the state label - the accent rides on its own gate.
+  if key ~= frame.colorKey or widget.accent ~= frame.accentKey then
+    frame.colorKey = key
+    frame.accentKey = widget.accent
+    applyColors(widget, key)
+  end
+
+  U.applyStateInk(widget)
+  updateText(widget)
+  updateArc(widget)
+  updateHistory(widget)
+  -- The pill, not the arc. Modulating the value arc's opacity took the
+  -- critical red down to 1.74:1 against a dark theme at the trough - the data
+  -- channel disappearing to announce that it matters. The pill is the status
+  -- channel and CRIT keeps it on screen even with the chip option off, which
+  -- is what makes it the safe carrier here and on the bar (bar.lua).
+  if ui.chip then
+    ui.pulseTargets = ui.pulseTargets
+      or { ui.chip, ui.chipEdge, ui.stateLabel }
+    U.updatePulse(widget, key, ui.pulseTargets)
+  end
+
+  U.flush(widget)
+  frame.prevAvail = widget.data.availability
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/format.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/format.lua
@@ -1,0 +1,67 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - value formatting                                           #
+---- #                                                                       #
+---- # Shared by layout (to size the value area from the widest string the   #
+---- # scale can produce) and by the renderers (to print the live value).    #
+---- # Pure Lua apart from string.format.                                    #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local floor, abs = math.floor, math.abs
+
+-- Two dashes, not one. A single hyphen set at the value font's size (29 px on
+-- a 220x170 dial) renders as one short, thick, vertically centred bar floating
+-- where a number should be: on the real firmware it reads as a stray
+-- rectangle, not as "no reading". Two read unambiguously as a placeholder at
+-- every size in the ramp, and still fit the reserved box, which is sized from
+-- the scale endpoints plus a character of slack (M.widestSample).
+M.NO_VALUE = "--"
+
+function M.number(v, precision)
+  if type(v) ~= "number" or v ~= v then return M.NO_VALUE end
+  if precision == 1 then return string.format("%.1f", v) end
+  if precision == 2 then return string.format("%.2f", v) end
+  return string.format("%.0f", v)
+end
+
+-- Timers report seconds; display hh:mm:ss. A negative value is an elapsed
+-- countdown timer (official Value widget behaviour).
+function M.hms(v)
+  if type(v) ~= "number" or v ~= v then return "--:--:--" end
+  local n = abs(v)
+  local sign = (v < 0) and "-" or ""
+  return sign .. string.format("%02d:%02d:%02d", floor(n / 3600),
+    floor((n % 3600) / 60), floor(n % 60))
+end
+
+-- Live value string for the current source.
+function M.display(widget, v)
+  if v == nil then return M.NO_VALUE end
+  if widget.source.isTimer then return M.hms(v) end
+  return M.number(v, widget.config.precision)
+end
+
+-- Widest string the configured scale can produce. Used once per layout pass
+-- to reserve the value area, so the digits never move as the value changes
+-- (an instrument keeps its ones digit in place).
+function M.widestSample(widget)
+  local cfg = widget.config
+  -- Timers print as hh:mm:ss and an ELAPSED timer carries a leading sign, so
+  -- the sample must be the signed width: a box sized for "00:00:00" wraps the
+  -- real "-00:01:05" and clips it (AUDIT.md P1-3).
+  if widget.source.isTimer then return "-00:00:00" end
+  local a = M.display(widget, cfg.min)
+  local b = M.display(widget, cfg.max)
+  local sample = (#b >= #a) and b or a
+  -- The value is deliberately NOT clamped to the scale - an instrument must
+  -- tell the truth - so an out-of-range value can be one character wider
+  -- than the range's widest string. Reserve that one character of slack, or
+  -- the extra digit wraps inside the fixed value box (AUDIT.md P1-4).
+  return "-" .. sample
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/geometry.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/geometry.lua
@@ -1,0 +1,175 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - geometry helpers (pure Lua, no firmware dependencies)      #
+---- #                                                                       #
+---- # Angle convention matches LVGL: 0 deg = 3 o'clock, angles increase     #
+---- # clockwise (screen y points down).                                     #
+---- #                                                                       #
+---- # Point tables are {x, y} pairs - the exact format the EdgeTX binding   #
+---- # reads (LvglWidgetLine::getPt uses rawgeti(pt,1)/rawgeti(pt,2)); named  #
+---- # {x = ...} points fail on the radio.                                   #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local floor = math.floor
+local cos = math.cos
+local sin = math.sin
+local rad = math.pi / 180
+
+function M.clamp(value, lo, hi)
+  if value < lo then return lo end
+  if value > hi then return hi end
+  return value
+end
+
+-- Position of `value` inside [minimum, maximum] as 0..1.
+-- Inverted ranges (minimum > maximum) are mirrored rather than swapped, so a
+-- descending scale (e.g. 0 at the right) maps correctly - the official C++
+-- gauge's "value - min - max" transform is degenerate for asymmetric ranges.
+function M.normalize(value, minimum, maximum)
+  if maximum == minimum then return 0 end
+  local t = (value - minimum) / (maximum - minimum)
+  -- NaN survives clamp() untouched - neither `t < 0` nor `t > 1` is true of
+  -- it - and every angle and bar width on the widget is derived from this
+  -- one function, so a single NaN here reaches lvgl.set as a non-integer
+  -- and raises on the radio. telemetry.refresh rejects non-finite READINGS
+  -- at the gate; this catches a NaN arriving from anywhere else (a degenerate
+  -- min/max pair, a caller passing a computed bound).
+  if t ~= t then return 0 end
+  return M.clamp(t, 0, 1)
+end
+
+function M.valueToAngle(value, minimum, maximum, startAngle, sweepAngle)
+  return startAngle + M.normalize(value, minimum, maximum) * sweepAngle
+end
+
+function M.pointOnCircle(cx, cy, radius, angle)
+  local a = angle * rad
+  return cx + radius * cos(a), cy + radius * sin(a)
+end
+
+-- Radial line from r1 to r2 at `angle`.
+function M.linePoints(cx, cy, r1, r2, angle)
+  local x1, y1 = M.pointOnCircle(cx, cy, r1, angle)
+  local x2, y2 = M.pointOnCircle(cx, cy, r2, angle)
+  return { { x1, y1 }, { x2, y2 } }
+end
+
+-- Same line, written INTO a caller-owned buffer instead of allocating:
+-- the binding copies the values out on every set (LvglWidgetLine::getPts,
+-- lua_lvgl_widget.cpp:1008-1029) and retains no reference to the Lua table,
+-- so mutating a reused buffer is legal and removes the per-frame allocation
+-- the needle's three segments made (Tanda 6 F-11 / Phase 5.1). The buffer
+-- must keep #buf == 2 (lua_rawlen drives getPts).
+function M.linePointsInto(buf, cx, cy, r1, r2, angle)
+  local x1, y1 = M.pointOnCircle(cx, cy, r1, angle)
+  local x2, y2 = M.pointOnCircle(cx, cy, r2, angle)
+  buf[1][1], buf[1][2] = x1, y1
+  buf[2][1], buf[2][2] = x2, y2
+  return buf
+end
+
+M.tickPoints = M.linePoints
+
+-- Horizontal bar fill width for the linear (Bar) style.
+function M.barFill(width, value, minimum, maximum)
+  return floor(width * M.normalize(value, minimum, maximum) + 0.5)
+end
+
+-- NEVER compare a fractional number with `== 0` or `== 1` on this firmware.
+--
+-- EdgeTX builds Lua with `LUA_FLOORN2I 1` (radio/src/thirdparty/Lua/src/
+-- luaconf.h:164) so its API can take unrounded floats where an integer is
+-- required. That macro is also what `luaV_equalobj` uses for a float/integer
+-- pair (lvm.c:404), so on the radio - and ONLY on the radio, never in the
+-- pure-Lua harness -
+--
+--     0.45 == 0    --> true
+--     1.75 == 1    --> true
+--     0.45 == 0.0  --> false   (float/float is exact)
+--     0.45 > 0     --> true    (ordering converts int->float, also exact)
+--
+-- Equality against a FLOAT literal and every inequality are safe; equality
+-- against an INTEGER literal silently floors. Use `> 0` / `>= 1`, or a
+-- boolean resolved once, as below. This cost the zero-origin bar option and
+-- every partial segment before it was found; see
+-- docs/visual-kit/INFORME-BAR-DIAL-2026-08-11.md.
+function M.isZero(n)
+  return n <= 0 and n >= 0
+end
+
+-- Orientation-neutral authored-scale axis. The descriptor is allocated once
+-- during layout and then reused by every body, threshold, head and history
+-- overlay. `start` is always the physical position of normalized 0: left for
+-- horizontal bars and bottom for vertical bars. Vertical therefore grows with
+-- -1 in screen coordinates while preserving the same normalized scale model.
+function M.makeAxis(rect, orientation, minimum, maximum, origin)
+  local vertical = orientation == "vertical"
+  local length = vertical and rect.h or rect.w
+  local start = vertical and (rect.y + rect.h) or rect.x
+  local growth = vertical and -1 or 1
+  local zeroInside = (minimum <= 0 and maximum >= 0)
+    or (maximum <= 0 and minimum >= 0)
+  local zeroT = M.normalize(0, minimum, maximum)
+  local wantsZero = origin == "zero"
+  local originT = wantsZero and zeroT or 0
+  local axis = {
+    orientation = vertical and "vertical" or "horizontal",
+    x = rect.x, y = rect.y, w = rect.w, h = rect.h,
+    start = start, length = length, growth = growth,
+    crossStart = vertical and rect.x or rect.y,
+    crossLength = vertical and rect.w or rect.h,
+    scaleLowT = 0, zeroT = zeroT, zeroInside = zeroInside,
+    origin = wantsZero and "zero" or "scale-low",
+    originT = originT,
+    -- Resolved ONCE, as a boolean, because every face asks this question on
+    -- every frame and `originT == 0` is exactly the comparison the firmware
+    -- gets wrong (see M.isZero). True means the fill is a prefix from the
+    -- scale low end, which is also where a clamped zero origin lands.
+    prefixOrigin = M.isZero(originT),
+    originClamped = wantsZero and not zeroInside or false,
+  }
+  axis.endCoord = start + growth * length
+  axis.originCoord = start + growth * floor(length * originT + 0.5)
+  axis.zeroCoord = start + growth * floor(length * zeroT + 0.5)
+  return axis
+end
+
+function M.axisPoint(axis, normalized)
+  normalized = M.clamp(tonumber(normalized) or 0, 0, 1)
+  return axis.start + axis.growth * floor(axis.length * normalized + 0.5)
+end
+
+-- Return a retained-rectangle-compatible x, y, w, h span between two
+-- normalized authored-scale positions. Either order is accepted, which is
+-- what lets a zero-origin value cross sign without face-local swapping.
+function M.axisSpan(axis, fromPosition, toPosition)
+  local p1 = M.axisPoint(axis, fromPosition)
+  local p2 = M.axisPoint(axis, toPosition)
+  if p1 > p2 then p1, p2 = p2, p1 end
+  if axis.orientation == "vertical" then
+    return axis.x, p1, axis.w, p2 - p1
+  end
+  return p1, axis.y, p2 - p1, axis.h
+end
+
+function M.axisOriginSpan(axis, normalized)
+  normalized = M.clamp(tonumber(normalized) or 0, 0, 1)
+  if normalized < axis.originT then return normalized, axis.originT end
+  return axis.originT, normalized
+end
+
+function M.round(n)
+  return floor(n + 0.5)
+end
+
+-- M.rayBoxEntry (slab-method ray/box intersection) lived here until Tanda 7.
+-- Its only caller was renderer.needleReach, which shortened the needle so it
+-- would not be drawn through the state chip - work the paint order already
+-- does, since the chip is opaque and created after the needle. Both went
+-- together; see the comment above updateArc in dial_renderer.lua.
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/layout_common.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/layout_common.lua
@@ -1,0 +1,405 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Core - shared responsive layout primitives                      #
+---- #                                                                       #
+---- # Classifies the zone (mode + orientation + style), computes dial       #
+---- # geometry and typography, and places every text into a REGION with an  #
+---- # alignment. The renderer never measures text at runtime: LVGL aligns   #
+---- # inside the region (lvgl.label supports align + w), so a changing      #
+---- # value cannot shift its neighbours.                                    #
+---- #                                                                       #
+---- # The value area is sized from the widest string the configured scale   #
+---- # can produce, so digits keep their position as the value moves.       #
+---- #                                                                       #
+---- # All physical sizes go through theme.px() (LCD_SCALE), so a "micro"    #
+---- # zone means the same physical size on every radio.                     #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local floor, min, max = math.floor, math.min, math.max
+
+local T  -- theme
+
+function M.setup(theme, _geometry, _format)
+  T = theme
+end
+
+M.STYLE_AUTO, M.STYLE_NEEDLE, M.STYLE_ARC, M.STYLE_BAR = 1, 2, 3, 4
+M.SWEEP_270, M.SWEEP_180, M.SWEEP_360 = 1, 2, 3
+M.COLOR_RAIL, M.COLOR_SECTIONS = 3, 5
+
+-- Sweep option -> { startAngle, sweep }. LVGL angles: 0 = 3 o'clock, clockwise.
+local SWEEPS = {
+  [M.SWEEP_270] = { 135, 270 },
+  [M.SWEEP_180] = { 180, 180 },
+  [M.SWEEP_360] = { 270, 360 },
+}
+
+local function clamp(v, lo, hi)
+  return max(lo, min(hi, v))
+end
+
+local function box(x, y, w, h)
+  return { x = floor(x), y = floor(y), w = floor(w), h = floor(h or 0) }
+end
+
+-- Width of the ring's clear interior over the vertical span [yTop, yBottom].
+--
+-- The chord narrows with distance from the dial centre, so the binding edge is
+-- whichever of the two is FARTHER from it. The old code always used the
+-- bottom, on the reasoning that "the ring is closest to the text at the bottom
+-- of its box" - true only while the box lies entirely below the centre. A
+-- micro dial centres its value ON the centre, so its box straddles it and the
+-- TOP edge is the far one: at 60x60 the value's top-right corner sat 13.4 px
+-- out on a 13 px clear radius while the bottom corners were comfortably
+-- inside. Taking the max of the two is the honest rule and costs one
+-- comparison.
+local function chordAt(L, yTop, yBottom)
+  local clearR = L.radius - floor(L.trackThickness / 2)
+  local dy = max(math.abs(yTop - L.cy), math.abs(yBottom - L.cy))
+  if clearR <= 0 or dy >= clearR then return 0 end
+  return 2 * math.sqrt(clearR * clearR - dy * dy)
+end
+
+-- Clip a box to that chord, centred on the dial centre, so every corner of
+-- the text stays inside the ring (the audit's LABEL/RING collisions: G-6 for
+-- the value, G-7 for the min/max row). One px of safety, because a box
+-- exactly as wide as the floored chord puts its corners on the ring and
+-- rounding can push them a hair outside.
+local function clipToChord(L, b)
+  if not b then return b end
+  local chord = chordAt(L, b.y, b.y + b.h)
+  if chord > 0 and chord < b.w then
+    b.w = floor(chord) - T.px(1)
+    b.x = L.cx - floor(b.w / 2)
+  end
+  return b
+end
+
+-- Stack text rows in the band [top, bottom], sharing whatever slack exists
+-- instead of pinning every gap at `xs` and leaving the remainder unused.
+--
+-- The dial's text block used to be built by chaining `+ T.px(T.space.xs)`
+-- between rows, which pins the gap at 2 px whatever the zone. Measured before
+-- this: a 260x220 dial had three 2 px gaps AND 15 px of dead space below the
+-- name; a 480x272 horizontal zone had 17 px between the value and the min/max
+-- row and 85 px between that and the name, because the name was anchored to
+-- the bottom of the text column regardless of where the content ended.
+--
+-- The gap is the slack divided between the rows, clamped to [xs, md] so a
+-- tight zone still collapses to the old spacing and a roomy one never drifts
+-- into looking disconnected. The block is then CENTRED in its band, so what
+-- is left over is split above and below rather than all falling to the bottom.
+--
+-- Returns nothing; the boxes are mutated in place.
+local function stackTextRows(top, bottom, rows, zoneH)
+  local n = #rows
+  if n == 0 then return end
+  local contentH = 0
+  for i = 1, n do contentH = contentH + rows[i].h end
+  local slack = (bottom - top) - contentH
+  local gap = clamp(floor(slack / max(n, 1)),
+                    T.px(T.space.xs), T.px(T.space.md))
+  local used = contentH + gap * (n - 1)
+  local y = top + max(floor(((bottom - top) - used) / 2), 0)
+  for i = 1, n do
+    local ry = floor(y)
+    -- The zone is the hard limit, as everywhere else. This matters because
+    -- the stack OVERWRITES positions that were already clamped once - the
+    -- value box in a horizontal zone is placed and clamped by placeValue and
+    -- then restacked here, so without this a 28x16 zone put the value label
+    -- 1 px below its own bottom edge. Rows may end up touching in a zone
+    -- this small; painting outside it is the worse outcome.
+    if zoneH and ry + rows[i].h > zoneH then
+      ry = max(zoneH - rows[i].h, 0)
+    end
+    rows[i].y = ry
+    y = y + rows[i].h + gap
+  end
+end
+
+-- Pixels the state pill hangs BELOW the state text box, outline included.
+--
+-- The pill is `extra` px taller than its text and vertically centred on it
+-- (chipOff = floor(extra / 2) above), so what hangs below is the half that
+-- floor() did NOT take - plus the chipEdge outline the renderers draw around
+-- the pill (renderer.build / bar.build).
+--
+-- `outline` is passed in, not restated, because that is the whole lesson of
+-- this function. The budget used to guess the overhang as floor(extra / 2),
+-- forgetting the outline entirely, and the pill left the bottom of every bar
+-- zone. The first repair hard-coded T.px(1) here - and px() is not linear:
+-- at LCD_SCALE 1.375 the renderers' `+ T.px(2)` on the outline box is 3, not
+-- 2 * T.px(1) = 2, so the pill went right back outside on 800 px radios.
+-- One value, defined once in the layout (L.chipOutline), used by the budget
+-- AND by both renderers.
+local function chipOverhang(shown, extra, outline)
+  if not shown then return 0 end
+  return extra - floor(extra / 2) + outline
+end
+
+-- mode: micro (<64), compact (<105), normal (<180), large (>=180)
+-- orientation: horizontal (>1.4), vertical (<0.8), balanced
+function M.classify(w, h)
+  local scale = (lvgl and lvgl.LCD_SCALE) or 1
+  local side = min(w, h)
+  local mode
+  if side < 64 * scale then mode = "micro"
+  elseif side < 105 * scale then mode = "compact"
+  elseif side < 180 * scale then mode = "normal"
+  else mode = "large" end
+  local ratio = w / h
+  local orientation
+  if ratio > 1.4 then orientation = "horizontal"
+  elseif ratio < 0.8 then orientation = "vertical"
+  else orientation = "balanced" end
+  return mode, orientation
+end
+
+-- A rotary dial needs area; in a long thin zone a linear bar is the honest
+-- instrument (GaugeRotary prints "too small" here, which helps nobody).
+function M.pickStyle(cfg, w, h, family)
+  if family == "dial" then return "dial" end
+  if family == "bar" then return "bar" end
+  if cfg.style == M.STYLE_BAR then return "bar" end
+  if cfg.style == M.STYLE_AUTO and (w / h) > 2.6 then return "bar" end
+  return "dial"
+end
+
+-- Largest font whose text fits both the width and the height available.
+-- `chordCtx` (balanced dials only) = { L = layout, region = valueRegion }.
+--
+-- Without it the caller pre-clips the region to the chord at the REGION's
+-- bottom edge and every font is judged against that one width. That is
+-- pessimistic by exactly the difference between the region height and the
+-- font height - the region is `dial.h * 0.26` tall, so a 24 px font was being
+-- measured against the chord ~11 px lower than the box it would actually
+-- occupy, where the ring has closed in. Measured at 200x160: the true chord
+-- for MIDSIZE is 74 px and the pair needs 72, but the region-depth chord said
+-- 61, so the value fell two ramp steps to STDSIZE - the same 16 px as its own
+-- `min 31` caption. That is the mechanism behind Tanda 5 P1-5.
+--
+-- With it, each candidate is judged against the chord at ITS OWN box bottom.
+-- The G-6 guarantee is unchanged - still the chord at the bottom of the box
+-- that actually gets drawn, still minus px(1) - it is simply no longer
+-- computed for a box nobody uses.
+-- Resolve the unit font for one value candidate. With no policy this is the
+-- established one-ramp-step behavior used by BarPro and every non-horizontal
+-- dial. A policy may instead select the available font closest to a target
+-- height ratio, while refusing candidates above a practical maximum and below
+-- its legibility floor.
+local function pickUnitFont(valueFont, policy)
+  if not policy then return T.smallerFont(valueFont, 1) end
+  local ramp = T.RAMP
+  local valueIndex
+  for i = 1, #ramp do
+    if ramp[i] == valueFont then valueIndex = i break end
+  end
+  if not valueIndex then return valueFont end
+
+  local minIndex = #ramp
+  if policy.unitMinFont then
+    for i = 1, #ramp do
+      if ramp[i] == policy.unitMinFont then minIndex = i break end
+    end
+  end
+  -- A policy is never allowed to promote the unit above the value. When the
+  -- value already sits at/below the floor, equal size is the only legible
+  -- fallback (this cannot occur in the normal/large horizontal caller).
+  if minIndex <= valueIndex then return valueFont end
+
+  local valueH = T.fontHeight(valueFont)
+  local target = policy.unitTargetRatio or 0.40
+  local maxRatio = policy.unitMaxRatio or 0.50
+  local best, bestDelta
+  for i = valueIndex + 1, minIndex do
+    local candidate = ramp[i]
+    local ratio = T.fontHeight(candidate) / valueH
+    if ratio <= maxRatio then
+      local delta = math.abs(ratio - target)
+      -- Strictly-less keeps the first candidate on a tie: the minimum number
+      -- of ramp steps that satisfies the same visual target.
+      if not bestDelta or delta < bestDelta then
+        best, bestDelta = candidate, delta
+      end
+    end
+  end
+  return best or ramp[minIndex] or valueFont
+end
+
+local function valueUnitGap(policy)
+  return (policy and policy.unitGap) or T.px(T.space.md)
+end
+
+local function pickValueFont(sample, unitText, maxW, maxH, cap, chordCtx,
+                             policy)
+  local ramp = T.RAMP
+  local gap = valueUnitGap(policy)
+  local heightLimit = maxH
+  if policy and policy.valueMaxHeight then
+    heightLimit = min(heightLimit, policy.valueMaxHeight)
+  end
+  local started = (cap == nil)
+  for i = 1, #ramp do
+    local font = ramp[i]
+    if not started and font == cap then started = true end
+    if started then
+      local fh = T.fontHeight(font)
+      if fh <= heightLimit then
+        local avail = maxW
+        if chordCtx then
+          local r = chordCtx.region
+          local y0 = chordCtx.topAlign and r.y
+            or (r.y + max(floor((r.h - fh) / 2), 0))
+          local c = floor(chordAt(chordCtx.L, y0, y0 + fh)) - T.px(1)
+          if c < avail then avail = c end
+        end
+        -- The default unit is one ramp step below the value (review P-D): two
+        -- steps shrank the `B` of `dB` to where it blurred into an `E` at
+        -- small sizes. A caller-supplied policy may choose a ratio-based font;
+        -- the same width fit below remains the final arbiter in both cases.
+        local unitFont = pickUnitFont(font, policy)
+        local w = T.textWidth(sample, font)
+        local uw = 0
+        if unitText and unitText ~= "" then
+          uw = T.textWidth(unitText, unitFont) + gap
+        end
+        if avail > 0 and w + uw <= avail then
+          return font, unitFont, w, uw, avail
+        end
+      end
+    end
+  end
+  -- Nothing fits the region: use the smallest font, but never let the
+  -- reserved box exceed the region. The region was chord-clipped to stay
+  -- inside the ring (AUDIT.md G-6), so an oversized box - possible once the
+  -- sample carries a slack character (P1-3/P1-4) - would push its corners
+  -- onto the ring. The value itself is always narrower than the sample.
+  local font = ramp[#ramp]
+  local unitFont = pickUnitFont(font, policy)
+  local uw = 0
+  if unitText and unitText ~= "" then
+    uw = T.textWidth(unitText, unitFont) + gap
+  end
+  -- The last-resort width must respect the chord too, or the fallback box -
+  -- the one case where the reserve CAN exceed what fits - lands on the ring.
+  local limit = maxW
+  if chordCtx then
+    local r = chordCtx.region
+    local fh = T.fontHeight(font)
+    local y0 = chordCtx.topAlign and r.y
+      or (r.y + max(floor((r.h - fh) / 2), 0))
+    limit = min(limit, max(floor(chordAt(chordCtx.L, y0, y0 + fh)) - T.px(1), 0))
+  end
+  local w = min(T.textWidth(sample, font), max(limit - uw, 0))
+  return font, unitFont, w, uw, limit
+end
+
+-- Place the value + unit pair centred as a group inside `region`.
+-- `chordCtx` is forwarded to pickValueFont; when present the group is centred
+-- on the DIAL centre rather than on the region, because the width it was
+-- fitted against is the ring's chord (symmetric about L.cx), not the region.
+local function placeValue(L, region, sample, unitText, cap, chordCtx, policy)
+  local valueFont, unitFont, vw, uw, avail =
+    pickValueFont(sample, unitText, region.w, region.h, cap, chordCtx, policy)
+  L.valueFont = valueFont
+  L.unitFont = unitFont
+  local vh = T.fontHeight(valueFont)
+  local uh = T.fontHeight(unitFont)
+  local gap = valueUnitGap(policy)
+  -- Shared with ui_core.anchorUnit: the reserved box and every live re-anchor
+  -- must read one resolved gap or the unit jumps after the first refresh.
+  L.unitGap = gap
+  local groupW = vw + uw
+  -- A trailing unit adds visual weight on the right of the group, so centre
+  -- it ~1 px left of the geometric centre when a unit is shown (review
+  -- P1-8). Only when there is room: never let the box leave the region, so
+  -- the G-6 chord guarantee holds.
+  -- The width the group was actually fitted against: the chord at the chosen
+  -- font's own box bottom when chordCtx is in play, the region otherwise.
+  local fitW = avail or region.w
+  local optical = 0
+  if unitText ~= "" and groupW + T.px(1) <= fitW then
+    optical = T.px(1)
+  end
+  local x0
+  if chordCtx then
+    -- the chord is symmetric about the dial centre, so centre the group there
+    x0 = L.cx - floor((groupW + optical) / 2)
+  else
+    x0 = region.x + floor((region.w - groupW - optical) / 2)
+  end
+  -- topAlign: the region's TOP is the P0-2 hub guarantee, and it is also
+  -- where the chord is widest, so the value sits there rather than floating
+  -- in the middle of a region sized for the largest candidate.
+  local y0 = (chordCtx and chordCtx.topAlign) and region.y
+    or (region.y + floor((region.h - vh) / 2))
+  if y0 < region.y then y0 = region.y end
+  -- The type ramp has a FLOOR (theme.RAMP's smallest font), so a region
+  -- shorter than that font still gets a box taller than itself - and in a
+  -- micro dial the region is already the zone's last few pixels, so the box
+  -- hung off the bottom edge of the widget (measured at 24x20, LCD_SCALE
+  -- 1.375: the value label ended 1 px outside). The region is the
+  -- preference; the zone is the hard limit. Only ever bites where the font
+  -- could not shrink far enough, so every zone with room is untouched.
+  if y0 + vh > L.h then y0 = max(L.h - vh, 0) end
+  if x0 < 0 then x0 = 0 end
+  L.valueBox = box(x0, y0, vw, vh)
+  -- P1-1 (Tanda 5 review 3.4): the box is reserved at the widest sample's
+  -- width so digits never shift the group, but RIGHT-aligning the actual
+  -- ink inside it flushed short values against the unit, leaving the empty
+  -- reserve entirely on the left - the visible "22 dB" sat well right of
+  -- the dial's centre even though the RESERVED group was centred there.
+  -- Centring the ink instead, with the unit re-anchored to its real edge
+  -- every time the value text changes (renderer.anchorUnit/bar.lua), keeps
+  -- the VISIBLE group centred on the same point for any digit count: with
+  -- the ink centred in a box of width vw, its own centre is always at
+  -- vw/2 regardless of actualW, so attaching the unit right after the ink
+  -- reproduces exactly the reserved group's centre, not an approximation.
+  L.valueAlign = CENTER
+  -- unit sits on the value baseline, one step down in the type ramp. `uw`
+  -- from pickValueFont already includes the gap, so the box must not add it
+  -- again: the reserved group is then exactly `groupW` and the fit check in
+  -- pickValueFont (w + uw <= maxW) is honest (AUDIT.md G-6).
+  L.unitBox = box(x0 + vw + gap, y0 + (vh - uh) - T.px(1), max(uw - gap, 1), uh)
+  L.unitAlign = LEFT
+end
+
+
+-- Family layouts consume these primitives; presentation geometry stays out
+-- of this common module while typography and containment remain one source.
+M.SWEEPS = SWEEPS
+M.clamp = clamp
+M.box = box
+M.chordAt = chordAt
+M.clipToChord = clipToChord
+M.stackTextRows = stackTextRows
+M.chipOverhang = chipOverhang
+M.pickValueFont = pickValueFont
+M.placeValue = placeValue
+
+-- Structural signature: a change here means the object tree must be rebuilt.
+-- Anything that only moves or recolours an existing object stays out of it.
+function M.signature(L, cfg)
+  return table.concat({
+    L.style, L.mode, L.orientation,
+    L.showNeedle and 1 or 0, L.showUnit and 1 or 0, L.showName and 1 or 0,
+    (L.showValue == false) and 0 or 1,
+    L.showState and 1 or 0, L.showMarkers and 1 or 0,
+    L.showMinMaxText and 1 or 0, L.showScale and 1 or 0,
+    cfg.colorMode, (L.style == "bar") and 0 or (cfg.sweep or 1),
+    L.valueFont, L.radius or 0,
+    L.w, L.h,
+    -- ShowChip no longer moves anything (F9 reserves the row either way), so
+    -- it does not belong here structurally - but the badge's VISIBILITY is
+    -- decided in updateChip, which only runs when the state STRING changes.
+    -- Without this, toggling the option while a NO LINK badge was on screen
+    -- left it there until the link state next moved.
+    (cfg.showChip == false) and 0 or 1,
+  }, ":")
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/motion.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/motion.lua
@@ -1,0 +1,445 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - bar motion language                                       #
+---- #                                                                       #
+---- # Motion explains a telemetry change; it never owns telemetry truth.   #
+---- # Raw state, alert decisions, badges, thresholds and numeric text stay  #
+---- # immediate. This module only derives a retained visual presentation:  #
+---- # a bounded color transition, dropout fade, segment settle and optional #
+---- # expressive head emphasis.                                             #
+---- #                                                                       #
+---- # Every transition uses scalar fields in one per-widget table. Colors  #
+---- # are precomputed when a transition starts and opacity is quantized, so #
+---- # a refresh creates no table/cache entry and cannot grow memory over    #
+---- # time. getTime() is always handled as 10 ms ticks.                     #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local abs, floor, max, min = math.abs, math.floor, math.max, math.min
+
+local T
+local segmentedFace
+
+-- Durations are 10 ms ticks. Refined's 180 ms and Expressive's 220 ms sit
+-- inside the plan's 150-220 ms state-color bound. Four visible steps are
+-- deliberate: enough temporal continuity to explain the change, but a hard
+-- ceiling on color/opacity writes and no per-frame palette cache churn.
+M.PROFILES = {
+  off = {
+    pulse = "off", colorTicks = 0, fadeTicks = 0,
+    settleTicks = 0, headTicks = 0,
+  },
+  essential = {
+    pulse = "essential", colorTicks = 0, fadeTicks = 18,
+    settleTicks = 0, headTicks = 0,
+  },
+  refined = {
+    pulse = "refined", colorTicks = 18, fadeTicks = 18,
+    settleTicks = 16, headTicks = 0,
+  },
+  expressive = {
+    pulse = "refined", colorTicks = 22, fadeTicks = 18,
+    settleTicks = 22, headTicks = 22,
+  },
+}
+
+local PAUSE_TICKS = 50       -- >500 ms means refresh was not visible/running
+local COLOR_STEPS = 4
+local FADE_STEPS = 4
+
+function M.setup(theme)
+  T = theme
+end
+
+function M.effectiveProfile(widget)
+  local visual = widget and widget.barVisual
+  if visual and visual.effectiveMotion then
+    return visual.effectiveMotion, visual.motionReduced or false
+  end
+  local requested = visual and visual.motion or "refined"
+  if not M.PROFILES[requested] then requested = "refined" end
+  local family = visual and visual.profile and visual.profile.family
+    or "standard"
+  -- Expressive is intentionally absent from the two smallest families. The
+  -- same authored choice becomes Refined there: meaning and damping survive,
+  -- but the optional head/cascade emphasis cannot compete with tiny data.
+  if requested == "expressive" and (family == "micro" or family == "short") then
+    return "refined", true
+  end
+  return requested, false
+end
+
+local function clearState(m)
+  m.initialized = false
+  -- Lua removes nil-valued keys. Scalar sentinels keep the complete retained
+  -- footprint materialized before the first warning tween or dropout.
+  m.profile = false
+  m.expressive = false
+  m.paletteSig = false
+  m.visualContract = false
+  m.lastAt = 0
+  m.rawState = false
+  m.rawValid = false
+  m.rawNormalized = 0
+  m.lastNormalized = 0
+  m.lastValue = false
+  m.visualColor = 0
+  m.targetColor = 0
+  m.colorActive = false
+  m.colorAt = 0
+  m.color1, m.color2, m.color3 = 0, 0, 0
+  m.fadeActive = false
+  m.fadeAt = 0
+  m.fadeFrom = 0
+  m.fadeNormalized = 0
+  m.fadeValue = false
+  m.segmented = false
+  m.segmentCount = 1
+  m.originT = 0
+  m.settleAllowed = false
+  m.segmentIndex = false
+  m.segmentDistance = 0
+  m.settleIndex = false
+  m.settleAt = 0
+  m.headAt = 0
+  m.headActive = false
+  m.headArmed = true
+  m.fastEligible = false
+  m.requiresFrameMotion = false
+end
+
+local function configureGeometry(widget, m)
+  local visual = widget.barVisual
+  local family = visual and visual.profile and visual.profile.family
+    or "standard"
+  m.segmented = segmentedFace and segmentedFace(widget) or false
+  m.segmentCount = max(1, floor(tonumber(visual and visual.renderedSegments
+    or visual and visual.segments) or 1))
+  m.originT = widget.layout and widget.layout.axis
+    and widget.layout.axis.originT or 0
+  -- A whole-cell highlight is cheap for Blocks/Steps. True Hex would repaint
+  -- three LVGL objects per highlighted cell and Fine Ticks is deliberately a
+  -- dense reference grid; both keep the precise damped head instead. This is
+  -- the plan's frame-budget cap, chosen at build rather than after overruns.
+  local name = widget.barFaceName
+  m.settleAllowed = (name == "blocks" or name == "steps")
+    and m.segmentCount <= 12 and family ~= "micro" and family ~= "short"
+end
+
+function M.reset(widget)
+  local m = widget.motionState
+  local segmented, segmentCount, originT, settleAllowed
+  if m then
+    segmented, segmentCount = m.segmented, m.segmentCount
+    originT, settleAllowed = m.originT, m.settleAllowed
+  end
+  if not m then
+    m = {}
+    widget.motionState = m
+  end
+  clearState(m)
+  -- Source/range resets can be non-structural. Preserve already-built face
+  -- geometry in that path; M.build immediately recalculates it after a real
+  -- tree/layout rebuild.
+  if segmentCount then
+    m.segmented, m.segmentCount = segmented, segmentCount
+    m.originT, m.settleAllowed = originT, settleAllowed
+  end
+  -- segmentedFace is declared below this function in source order, so build
+  -- refreshes geometry once all locals are initialized (reset may also be
+  -- called from app.lua before a bar tree exists).
+  return m
+end
+
+function M.build(widget)
+  local m = M.reset(widget)
+  configureGeometry(widget, m)
+  return m
+end
+
+local function prime(widget, m, state, targetColor, paletteSig, profile, now)
+  m.initialized = true
+  m.profile = profile
+  m.expressive = profile == "expressive"
+  m.visualContract = widget.barVisual
+  m.fastEligible = profile ~= "expressive" and not m.settleAllowed
+  m.requiresFrameMotion = m.settleAllowed
+  m.paletteSig = paletteSig
+  m.lastAt = now
+  m.rawState = state.state
+  m.rawValid = state.valid
+  m.rawNormalized = state.rawNormalized or 0
+  m.visualColor = targetColor
+  m.targetColor = targetColor
+  m.colorActive = false
+  m.fadeActive = false
+  m.settleIndex = false
+  m.headActive = false
+  m.headArmed = true
+  if state.valid then
+    m.lastNormalized = state.smoothNormalized or state.rawNormalized or 0
+    m.lastValue = state.smoothValue
+  end
+end
+
+local function directState(state, targetColor, profile, reduced, paused)
+  state.visualColor = targetColor
+  state.visualValid = state.valid
+  state.opacity = state.rawOpacity
+    or (state.valid and T.opacity.full or T.opacity.muted)
+  state.motionProfile = profile
+  state.motionReduced = reduced
+  state.motionPaused = paused or false
+  state.pulseMode = M.PROFILES[profile].pulse
+  state.colorTransition = false
+  state.settleIndex, state.settleLevel = nil, 0
+  state.headBoost = 0
+  state.motionActive = false
+end
+
+local function startColor(m, targetColor, now, duration)
+  local from = m.visualColor or m.targetColor or targetColor
+  m.targetColor = targetColor
+  m.colorAt = now
+  m.colorActive = duration > 0 and from ~= targetColor
+  if not m.colorActive then
+    m.visualColor = targetColor
+    return
+  end
+  -- Fixed scalar slots, not a transition table and not the global palette
+  -- cache. The exact authored target is restored byte-for-byte at step four.
+  m.color1 = T.mixColor(from, targetColor, 0.25)
+  m.color2 = T.mixColor(from, targetColor, 0.50)
+  m.color3 = T.mixColor(from, targetColor, 0.75)
+end
+
+local function colorStep(m, now, duration)
+  if not m.colorActive then return m.visualColor end
+  local step = floor((now - m.colorAt) * COLOR_STEPS / duration)
+  if step <= 0 then
+    return m.visualColor
+  elseif step == 1 then
+    m.visualColor = m.color1
+  elseif step == 2 then
+    m.visualColor = m.color2
+  elseif step == 3 then
+    m.visualColor = m.color3
+  else
+    m.visualColor = m.targetColor
+    m.colorActive = false
+  end
+  return m.visualColor
+end
+
+local function fadeOpacity(from, target, elapsed, duration)
+  local step = floor(elapsed * FADE_STEPS / duration)
+  if step <= 0 then return from, false end
+  if step >= FADE_STEPS then return target, true end
+  return floor(from + (target - from) * step / FADE_STEPS + 0.5), false
+end
+
+segmentedFace = function(widget)
+  local name = widget.barFaceName
+  return name == "blocks" or name == "hex"
+    or name == "ticks" or name == "steps"
+end
+
+local function segmentMotion(_widget, state, m, effect, now, allowTrigger)
+  state.settleIndex, state.settleLevel = nil, 0
+  if effect.settleTicks <= 0 or not state.valid or not m.settleAllowed then
+    m.settleIndex = false
+    return
+  end
+  local count = m.segmentCount
+  local normalized = max(0, min(1, state.smoothNormalized or 0))
+  local origin = m.originT
+  local distance = abs(normalized - origin)
+  local index = min(count, max(1, floor(normalized * count) + 1))
+
+  if allowTrigger and m.segmentIndex and index ~= m.segmentIndex
+     and distance > m.segmentDistance + 0.0001 then
+    m.settleIndex = index
+    m.settleAt = now
+  end
+  m.segmentIndex, m.segmentDistance = index, distance
+
+  if m.settleIndex then
+    local elapsed = now - m.settleAt
+    if elapsed < effect.settleTicks then
+      state.settleIndex = m.settleIndex
+      state.settleLevel = (elapsed * 2 < effect.settleTicks) and 2 or 1
+    else
+      m.settleIndex = false
+    end
+  end
+end
+
+local function headMotion(state, m, effect, now, allowTrigger)
+  state.headBoost = 0
+  if effect.headTicks <= 0 or not state.valid then
+    m.headActive = false
+    m.headArmed = true
+    return
+  end
+  local raw = state.rawNormalized or 0
+  local delta = abs(raw - (m.rawNormalized or raw))
+  if not m.headActive and not m.headArmed and delta < 0.02 then
+    m.headArmed = true
+  end
+  -- One material move gets one short emphasis. It cannot restart on every
+  -- noisy sample and become a permanent shimmer; a calm sample rearms it.
+  if allowTrigger and m.headArmed and not m.headActive and delta >= 0.08 then
+    m.headAt = now
+    m.headActive = true
+    m.headArmed = false
+  end
+  if m.headActive then
+    local elapsed = now - m.headAt
+    if elapsed < effect.headTicks then
+      state.headBoost = (elapsed * 2 < effect.headTicks) and 2 or 1
+    else
+      m.headActive = false
+    end
+  end
+end
+
+-- targetColor is resolved by bar.lua from the current palette. paletteSig is
+-- passed separately so a live HTX theme switch lands immediately instead of
+-- interpolating through colors that belong to two different themes.
+function M.update(widget, state, targetColor, paletteSig)
+  assert(T, "GaugePro: motion.setup was not called")
+  local m = widget.motionState or M.build(widget)
+  local profile, reduced = M.effectiveProfile(widget)
+  local effect = M.PROFILES[profile]
+  local now = getTime()
+
+  if not m.initialized then
+    prime(widget, m, state, targetColor, paletteSig, profile, now)
+    directState(state, targetColor, profile, reduced, false)
+    state.settleEnabled = m.settleAllowed
+    -- Seed the retained segment cursor without playing an activation effect
+    -- for the widget's first already-present sample.
+    segmentMotion(widget, state, m, effect, now, false)
+    return state
+  end
+
+  local paused = now - m.lastAt > PAUSE_TICKS
+  local contextChanged = profile ~= m.profile or paletteSig ~= m.paletteSig
+  if paused or contextChanged then
+    -- A hidden widget must not replay color/cascade time when it becomes
+    -- visible again. A profile or theme edit likewise starts from the exact
+    -- newly-authored endpoint rather than carrying old temporal state across.
+    prime(widget, m, state, targetColor, paletteSig, profile, now)
+    directState(state, targetColor, profile, reduced, paused)
+    state.settleEnabled = m.settleAllowed
+    segmentMotion(widget, state, m, effect, now, false)
+    return state
+  end
+
+  -- Ordinary valid telemetry is the hottest callback on the radio. When no
+  -- bounded transition is running and the semantic state is unchanged, take
+  -- the retained scalar path: gradient buckets may still change color
+  -- immediately, position damping still runs in smoothing.lua, and segmented
+  -- faces may still settle their leading cell, but none of the dropout/state
+  -- machinery below needs to execute.
+  if state.valid and m.rawValid and state.state == m.rawState
+     and not m.colorActive and not m.fadeActive and effect.headTicks == 0 then
+    m.targetColor, m.visualColor = targetColor, targetColor
+    state.motionPaused = false
+    state.visualValid = true
+    state.opacity = T.opacity.full
+    state.visualColor = targetColor
+    state.colorTransition = false
+    state.headBoost = 0
+    segmentMotion(widget, state, m, effect, now, true)
+    state.motionActive = state.settleLevel > 0
+    m.lastAt = now
+    m.lastNormalized = state.smoothNormalized or state.rawNormalized or 0
+    m.lastValue = state.smoothValue
+    m.rawNormalized = state.rawNormalized or 0
+    return state
+  end
+
+  state.motionProfile = profile
+  state.motionReduced = reduced
+  state.motionPaused = false
+  state.pulseMode = effect.pulse
+  state.settleEnabled = m.settleAllowed
+  state.colorTransition = false
+  state.visualValid = state.valid
+  state.opacity = state.rawOpacity
+    or (state.valid and T.opacity.full or T.opacity.muted)
+
+  local wasValid = m.rawValid
+  if state.valid then
+    m.fadeActive = false
+    state.opacity = T.opacity.full
+    state.visualValid = true
+
+    local semanticChanged = state.state ~= m.rawState
+    local canTween = effect.colorTicks > 0 and wasValid and semanticChanged
+      and state.state ~= "critical"
+    if targetColor ~= m.targetColor then
+      if canTween then
+        startColor(m, targetColor, now, effect.colorTicks)
+      else
+        m.targetColor, m.visualColor = targetColor, targetColor
+        m.colorActive = false
+      end
+    end
+    state.visualColor = colorStep(m, now, effect.colorTicks)
+    state.colorTransition = m.colorActive
+    m.lastNormalized = state.smoothNormalized or state.rawNormalized or 0
+    m.lastValue = state.smoothValue
+  else
+    m.colorActive = false
+    if effect.fadeTicks > 0 and wasValid then
+      m.fadeActive = true
+      m.fadeAt = now
+      m.fadeFrom = T.opacity.full
+      m.fadeNormalized = m.lastNormalized
+      m.fadeValue = m.lastValue
+      -- Keep the last semantic color while its truthful geometry leaves. The
+      -- availability badge/text already changed above this module.
+      m.targetColor = targetColor
+    end
+    if m.fadeActive then
+      local done
+      state.opacity, done = fadeOpacity(m.fadeFrom, T.opacity.muted,
+        now - m.fadeAt, effect.fadeTicks)
+      state.visualValid = not done
+      state.smoothNormalized = m.fadeNormalized
+      state.smoothValue = m.fadeValue
+      if done then
+        m.fadeActive = false
+        m.visualColor = targetColor
+      end
+    else
+      state.opacity = T.opacity.muted
+      state.visualValid = false
+      m.visualColor, m.targetColor = targetColor, targetColor
+    end
+    state.visualColor = m.visualColor
+  end
+
+  local allowTrigger = not paused and wasValid
+  segmentMotion(widget, state, m, effect, now, allowTrigger)
+  headMotion(state, m, effect, now, allowTrigger)
+  m.requiresFrameMotion = m.settleAllowed or m.headActive
+    or m.colorActive or m.fadeActive
+  state.motionActive = m.colorActive or m.fadeActive
+    or state.settleLevel > 0 or state.headBoost > 0
+
+  m.profile = profile
+  m.paletteSig = paletteSig
+  m.lastAt = now
+  m.rawState = state.state
+  m.rawValid = state.valid
+  m.rawNormalized = state.rawNormalized or 0
+  return state
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/options.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/options.lua
@@ -1,0 +1,113 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - widget option wire format                                  #
+---- #                                                                       #
+---- # THE OPTION CONTRACT (verified against radio/src, EdgeTX 3.0):         #
+---- #                                                                       #
+---- #  * The firmware hands options to Lua as NUMBERS, never strings,       #
+---- #    except String/File options:                                        #
+---- #      lua_widget.cpp updateWithoutRefresh()                            #
+---- #        String/File     -> lua_pushstring                              #
+---- #        Integer/Switch  -> lua_pushinteger (signed)                    #
+---- #        everything else -> lua_pushinteger (unsigned)                  #
+---- #    Comparing a CHOICE option against its label string can therefore   #
+---- #    never match.                                                       #
+---- #                                                                       #
+---- #  * CHOICE values are stored 1-BASED: the settings dialog reads        #
+---- #    getUnsignedValue(i) - 1 and writes newValue + 1                    #
+---- #    (widget_settings.cpp). Declared defaults must be 1-based too; a    #
+---- #    stored 0 means "never edited" and falls back to the default.       #
+---- #                                                                       #
+---- #  * Option slots are POSITIONAL and typed. setDefault() resets a slot  #
+---- #    only when the stored type differs, so options may only ever be     #
+---- #    APPENDED - inserting or reordering silently reinterprets saved     #
+---- #    model data (widget.cpp:383).                                       #
+---- #                                                                       #
+---- #  * Capacity is version dependent:                                     #
+---- #      2.11.x  MAX_WIDGET_OPTIONS = 10 (radio and Companion)            #
+---- #      2.12+   MAX_WIDGET_OPTIONS = 50                                  #
+---- #    Excess options are truncated (lua_widget_factory.cpp:291), so the  #
+---- #    first ten declarations are the ones that must matter.              #
+---- #                                                                       #
+---- # Pure Lua except for the option-type constants; unit-testable.         #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+M.CORE_CAPACITY = 10
+M.EXTENDED_CAPACITY = 50
+
+-- How many option slots this firmware supports.
+function M.capacity()
+  if type(getVersion) ~= "function" then return M.CORE_CAPACITY end
+  local _, _, maj, minor = getVersion()
+  maj, minor = tonumber(maj), tonumber(minor)
+  if not maj then return M.CORE_CAPACITY end
+  if maj > 2 or (maj == 2 and (minor or 0) >= 12) then
+    return M.EXTENDED_CAPACITY
+  end
+  return M.CORE_CAPACITY
+end
+
+-- NOTE (Tanda 6 F-14 / 6.1): the option-declaration builder and the label
+-- translator are NOT here. They live inline in main.lua - which runs at boot
+-- for every widget on the card, used or not - so boot costs exactly one file
+-- read per widget. This module's versions were deleted in Tanda 6 after
+-- verifying both builders byte-identical (boot-cost check: inline=24,
+-- build=24, differences 0): ONE builder remains, so the two can never drift.
+
+-- ------------------------------------------------------------- conversion --
+
+-- CHOICE -> 1..#choices. Accepts the stored 1-based value, falls back to the
+-- declared default for 0 ("never edited") or anything out of range.
+local function choiceOf(raw, count, default)
+  local v = tonumber(raw)
+  if not v or v < 1 or v > count then return default end
+  return v
+end
+M.choiceOf = choiceOf
+
+local function boolOf(raw, default)
+  local v = tonumber(raw)
+  if v == nil then return default end
+  return v ~= 0
+end
+
+local function numberOf(raw, default)
+  return tonumber(raw) or default
+end
+
+local function stringOf(raw)
+  if type(raw) ~= "string" then return "" end
+  return raw
+end
+
+-- Parse the raw option table into a typed config keyed by `field`.
+-- Options missing from `raw` (older firmware, truncated tail) fall back to
+-- their declared defaults, so every consumer sees a complete config.
+function M.parse(defs, raw)
+  raw = raw or {}
+  local cfg = {}
+  for i = 1, #defs do
+    local d = defs[i]
+    if d.field then
+      local value = raw[d.key]
+      if d.type == CHOICE then
+        cfg[d.field] = choiceOf(value, #d.choices, d.default)
+      elseif d.type == BOOL then
+        cfg[d.field] = boolOf(value, d.default ~= 0)
+      elseif d.type == STRING then
+        cfg[d.field] = stringOf(value)
+      elseif d.type == SOURCE then
+        cfg[d.field] = numberOf(value, 0)
+      else  -- VALUE, SLIDER, SWITCH, COLOR
+        cfg[d.field] = numberOf(value, d.default)
+      end
+    end
+  end
+  return cfg
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/presets.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/presets.lua
@@ -1,0 +1,268 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - known-sensor presets and battery maths                     #
+---- #                                                                       #
+---- # Matching order: exact source name (normalized), then unit fallback    #
+---- # for telemetry sources. Presets only initialize values while the       #
+---- # Scale option is Auto.                                                 #
+---- #                                                                       #
+---- # Battery helpers: cell-count detection from pack voltage and a         #
+---- # discharge-curve percentage, the way BattAnalog / the community        #
+---- # battery widgets do it. Voltage alone is a poor state-of-charge        #
+---- # indicator - the curve makes the gauge mean something.                 #
+---- #                                                                       #
+---- # Pure Lua, no firmware dependencies.                                   #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+-- Units are the EdgeTX TelemetryUnit enum (dataconstants.h):
+-- 1=V 2=A 3=mA 4=kts 5=m/s 7=km/h 9=m 11=degC 12=degF 13=% 14=mAh 15=W
+-- 17=dB 18=rpm 28=km 29=dBm
+local PRESETS = {
+  {
+    names = { "RSSI", "RSSI1", "RSSI2", "RSSI3" },
+    units = { 17 },
+    kind = "signal",
+    minimum = 0, maximum = 100, warning = 55, critical = 35, highIsGood = true,
+  },
+  {
+    names = { "1RSS", "2RSS", "TRSS" },
+    units = { 29 },
+    kind = "signal",
+    minimum = -120, maximum = 0, warning = -80, critical = -95,
+    highIsGood = true,
+  },
+  {
+    names = { "RQly", "RQly%", "TQly", "VFR%", "VFR" },
+    kind = "signal",
+    minimum = 0, maximum = 100, warning = 55, critical = 35, highIsGood = true,
+  },
+  {
+    names = { "SNR" },
+    kind = "signal",
+    minimum = -20, maximum = 20, warning = 2, critical = -5, highIsGood = true,
+  },
+  {
+    names = { "RxBt", "RxBatt", "Batt", "Vbat", "VFAS" },
+    units = { 1 },
+    kind = "battery",
+    minimum = 0, maximum = 8.4, warning = 3.7, critical = 3.5, highIsGood = true,
+    battery = true,
+  },
+  {
+    names = { "TxBat", "TxBatt", "Battery", "tx-voltage" },
+    kind = "battery",
+    minimum = 6, maximum = 8.4, warning = 6.8, critical = 6.4, highIsGood = true,
+  },
+  {
+    -- cellsTable: getSourceValue() returns one entry PER CELL for this
+    -- sensor (api_general.cpp luaPushCells), unlike RxBt/VFAS above which is
+    -- a single pack-total reading. The pack-range rescale in app.lua only
+    -- makes sense for a value that IS the pack total (AUDIT.md P1-6) -
+    -- Lowest and Average stay single-cell magnitude regardless of pack size.
+    names = { "Cell", "Cells", "Cels", "Cel#" },
+    kind = "battery",
+    minimum = 3.0, maximum = 4.2, warning = 3.7, critical = 3.5,
+    highIsGood = true, battery = true, cellsTable = true,
+  },
+  {
+    names = { "Tmp", "Temp", "Temperature", "Tmp1", "Tmp2", "TFET", "TBEC" },
+    units = { 11, 12 },
+    kind = "temperature",
+    minimum = 0, maximum = 120, warning = 70, critical = 90, highIsGood = false,
+  },
+  {
+    names = { "RPM", "RPMs", "Turbine", "Hspd" },
+    units = { 18 },
+    minimum = 0, maximum = 20000, warning = 16000, critical = 18000,
+    highIsGood = false,
+  },
+  {
+    names = { "Curr", "Current" },
+    units = { 2 },
+    minimum = 0, maximum = 100, warning = 70, critical = 85, highIsGood = false,
+  },
+  {
+    names = { "Capa", "Capacity", "Consumption", "mAh" },
+    units = { 14 },
+    kind = "capacity",
+    minimum = 0, maximum = 5000, warning = 3500, critical = 4500,
+    highIsGood = false,
+  },
+  {
+    names = { "Fuel", "Bat%", "Rem" },
+    kind = "capacity",
+    minimum = 0, maximum = 100, warning = 30, critical = 15, highIsGood = true,
+  },
+  {
+    names = { "Thr", "Throttle" },
+    -- Throttle is deliberately not a centred control. Treating it like a
+    -- stick/channel would invent a neutral midpoint and select Dual Rail for
+    -- a unipolar source.
+    kind = "throttle",
+    minimum = 0, maximum = 100, warning = 80, critical = 95, highIsGood = false,
+  },
+  {
+    names = { "Alt", "Altitude", "GAlt" },
+    units = { 9 },
+    minimum = 0, maximum = 400, warning = 300, critical = 380,
+    highIsGood = false,
+  },
+  {
+    names = { "GSpd", "GPSspeed", "ASpd" },
+    units = { 4, 5, 7 },
+    minimum = 0, maximum = 150, warning = 120, critical = 140,
+    highIsGood = false,
+  },
+  {
+    names = { "Dist", "Distance" },
+    units = { 28 },
+    minimum = 0, maximum = 1000, warning = 700, critical = 900,
+    highIsGood = false,
+  },
+  {
+    names = { "Sats", "Satellites" },
+    kind = "signal",
+    minimum = 0, maximum = 24, warning = 8, critical = 5, highIsGood = true,
+  },
+  {
+    names = { "Vibr", "Vibration" },
+    minimum = 0, maximum = 100, warning = 40, critical = 60, highIsGood = false,
+  },
+}
+
+local function normName(s)
+  if type(s) ~= "string" then return "" end
+  -- string methods (s:lower()) are unavailable on EdgeTX Lua builds without
+  -- LUA_ENABLE_STRLIB_MT, so use the string library functions explicitly
+  return (string.gsub(string.lower(s), "[^%w]", ""))
+end
+M.normName = normName
+
+-- Find a preset for a resolved source { name = ..., unit = ... }.
+function M.find(source)
+  if not source or not source.name then return nil end
+  local name = normName(source.name)
+  if name == "" then return nil end
+  for i = 1, #PRESETS do
+    local p = PRESETS[i]
+    for j = 1, #p.names do
+      if normName(p.names[j]) == name then return p end
+    end
+  end
+  if source.unit then
+    for i = 1, #PRESETS do
+      local p = PRESETS[i]
+      if p.units then
+        for j = 1, #p.units do
+          if p.units[j] == source.unit then
+            if not p.battery then return p end
+            -- Battery/cell detection is only trustworthy from an exact NAME
+            -- match: matching by unit alone (any unlabelled Volt sensor)
+            -- must not inherit it, or an unrelated voltage sensor (a BEC, a
+            -- servo rail) permanently latches a cell count and gets
+            -- rescaled to a battery pack range it has nothing to do with
+            -- (AUDIT.md P1-7).
+            local copy = {}
+            for k, v in pairs(p) do copy[k] = v end
+            copy.battery = nil
+            copy.cellsTable = nil
+            return copy
+          end
+        end
+      end
+    end
+  end
+  return nil
+end
+
+-- Stable semantic hint for the opt-in Auto Source APPEARANCE preset. This is
+-- intentionally coarse: it may select a useful face, but never changes the
+-- scale, thresholds, alerts, or telemetry transforms owned above.
+function M.kind(source)
+  local preset = M.find(source)
+  if preset and preset.kind then return preset.kind end
+  local name = normName(source and source.name)
+  -- Stable EdgeTX source families whose native meaning is signed around a
+  -- neutral centre. This hint selects appearance only; scale ownership stays
+  -- in app.lua and the user's Scale setting.
+  if name == "ail" or name == "ele" or name == "rud"
+     or string.find(name, "^ch%d+$")
+     or string.find(name, "^trm[%a%d]+$")
+     or string.find(name, "^trim[%a%d]+$")
+     or string.find(name, "^gv%d+$")
+     or string.find(name, "^gvar%d+$") then
+    return "control"
+  end
+  return "generic"
+end
+
+-- ---------------------------------------------------------------- battery --
+
+-- Chemistry limits: { full, empty, curve }. The curve is a voltage -> percent
+-- polyline for one cell; linear interpolation between points. Approximations
+-- of a resting discharge curve, matching what the battery widgets in the
+-- ecosystem use.
+M.CHEMISTRY = {
+  lipo = {
+    full = 4.2, empty = 3.3, nominal = 4.35,
+    curve = {
+      { 3.30, 0 }, { 3.50, 5 }, { 3.60, 10 }, { 3.65, 15 }, { 3.70, 25 },
+      { 3.75, 35 }, { 3.80, 45 }, { 3.85, 55 }, { 3.90, 65 }, { 3.95, 75 },
+      { 4.00, 85 }, { 4.10, 95 }, { 4.20, 100 },
+    },
+  },
+  liion = {
+    full = 4.2, empty = 2.8, nominal = 4.35,
+    curve = {
+      { 2.80, 0 }, { 3.10, 5 }, { 3.30, 10 }, { 3.50, 25 }, { 3.60, 40 },
+      { 3.70, 55 }, { 3.80, 70 }, { 3.90, 80 }, { 4.00, 90 }, { 4.10, 97 },
+      { 4.20, 100 },
+    },
+  },
+}
+
+-- Cell count from a pack voltage (BattAnalog / dbarrios83 heuristic).
+function M.cellCount(total, chemistry)
+  local chem = M.CHEMISTRY[chemistry] or M.CHEMISTRY.lipo
+  if type(total) ~= "number" or total <= 0 then return 1 end
+  local n = math.floor(total / chem.nominal) + 1
+  if n < 1 then n = 1 end
+  if n > 16 then n = 16 end
+  return n
+end
+
+-- State of charge (0..100) for a per-cell voltage.
+function M.percentFromCell(perCell, chemistry)
+  local chem = M.CHEMISTRY[chemistry] or M.CHEMISTRY.lipo
+  local curve = chem.curve
+  if type(perCell) ~= "number" then return nil end
+  if perCell <= curve[1][1] then return 0 end
+  if perCell >= curve[#curve][1] then return 100 end
+  for i = 2, #curve do
+    local v1, p1 = curve[i - 1][1], curve[i - 1][2]
+    local v2, p2 = curve[i][1], curve[i][2]
+    if perCell <= v2 then
+      return p1 + (p2 - p1) * (perCell - v1) / (v2 - v1)
+    end
+  end
+  return 100
+end
+
+-- Range for a pack of `cells` cells, so a total-voltage source gets a scale
+-- that matches the actual battery instead of a guessed 0..8.4 V.
+function M.packRange(cells, chemistry)
+  local chem = M.CHEMISTRY[chemistry] or M.CHEMISTRY.lipo
+  return {
+    minimum = chem.empty * cells,
+    maximum = chem.full * cells,
+    warning = 3.7 * cells,
+    critical = 3.5 * cells,
+    highIsGood = true,
+  }
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/ranges.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/ranges.lua
@@ -1,0 +1,132 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - semantic ranges and state detection                        #
+---- #                                                                       #
+---- # Builds the ordered normal/warning/critical bands from user options    #
+---- # and maps a value to its operational state, with hysteresis.           #
+---- #                                                                       #
+---- # Hysteresis rule: a worse state is adopted immediately (safety first), #
+---- # a better state only once the value has left the previous band by the  #
+---- # deadband. Without it a value resting on a threshold chatters between  #
+---- # two states on sensor noise - visible as colour flicker and audible as #
+---- # repeated alerts.                                                      #
+---- #                                                                       #
+---- # Pure Lua, no firmware dependencies.                                   #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local SEVERITY = { normal = 1, warning = 2, critical = 3 }
+M.SEVERITY = SEVERITY
+
+local function clamp(v, lo, hi)
+  if v < lo then return lo end
+  if v > hi then return hi end
+  return v
+end
+
+-- Build ascending bands from minimum to maximum.
+-- Returns { { role=..., from=..., to=... }, ... } (3 entries).
+-- Bands are always ascending in value space even when the scale is drawn
+-- inverted (geometry.normalize handles the drawing direction), and the
+-- warning/critical values are clamped into the range.
+function M.build(minimum, maximum, warning, critical, highIsGood)
+  if maximum < minimum then
+    minimum, maximum = maximum, minimum
+  end
+  local lo = clamp(math.min(warning, critical), minimum, maximum)
+  local hi = clamp(math.max(warning, critical), minimum, maximum)
+  local ranges
+  if highIsGood then
+    ranges = {
+      { role = "critical", from = minimum, to = lo },
+      { role = "warning",  from = lo,      to = hi },
+      { role = "normal",   from = hi,      to = maximum },
+    }
+  else
+    ranges = {
+      { role = "normal",   from = minimum, to = lo },
+      { role = "warning",  from = lo,      to = hi },
+      { role = "critical", from = hi,      to = maximum },
+    }
+  end
+  return ranges
+end
+
+-- Deadband width for a range, as a fraction of the span (default 2%).
+function M.deadband(minimum, maximum, fraction)
+  local span = math.abs(maximum - minimum)
+  -- `not (span > 0)`, never `span == 0`: this firmware floors a float before
+  -- comparing it with an integer literal, so a 0.5 V span read as zero and
+  -- the whole scale lost its hysteresis (see geometry.isZero).
+  if span <= 0 then return 0 end
+  return span * (fraction or 0.02)
+end
+
+-- If BOTH configured thresholds fall outside the effective range on the same
+-- side, the clamp in build() collapses them onto the same endpoint and the
+-- whole dial becomes one giant critical band - a manual -120..0 dBm scale
+-- with the 0..100 defaults (55/35) is born permanently red, with zero-width
+-- warning and normal bands (AUDIT.md G-4). Detect that case and derive the
+-- thresholds at the proportions the built-in presets use (35 % / 55 % of the
+-- span, mirrored for low-is-good) instead. An equal pair INSIDE the range is
+-- a deliberate sharp cliff and is left alone.
+-- Returns (warning, critical).
+function M.saneThresholds(minimum, maximum, warning, critical, highIsGood)
+  -- Same normalisation as build(): a descending scale (Min > Max) is a
+  -- supported configuration, not a mistake. Without it the guard below
+  -- fires on perfectly valid thresholds and derives them over a NEGATIVE
+  -- span - warn/crit inverted, a warning value rendered red and firing
+  -- the critical alert tone (Tanda 6 F-3).
+  if maximum < minimum then minimum, maximum = maximum, minimum end
+  local wl = math.min(warning, critical)
+  local wh = math.max(warning, critical)
+  if wh < minimum or wl > maximum then
+    local span = maximum - minimum
+    if highIsGood then
+      return minimum + 0.55 * span, minimum + 0.35 * span
+    end
+    return minimum + 0.45 * span, minimum + 0.65 * span
+  end
+  return warning, critical
+end
+
+local function rawState(value, ranges)
+  for i = 1, #ranges do
+    local r = ranges[i]
+    if value >= r.from and value <= r.to then
+      return r.role
+    end
+  end
+  -- outside the configured range: take the nearest boundary band
+  if value < ranges[1].from then return ranges[1].role end
+  return ranges[#ranges].role
+end
+
+local function bandOf(ranges, role)
+  for i = 1, #ranges do
+    if ranges[i].role == role then return ranges[i] end
+  end
+  return nil
+end
+
+-- Determine the state of a value.
+-- `previous` and `deadband` are optional; when both are given the result is
+-- hysteretic (see the header).
+function M.determineState(value, ranges, previous, deadband)
+  local raw = rawState(value, ranges)
+  if not previous or raw == previous then return raw end
+  if not deadband or deadband <= 0 then return raw end
+  if (SEVERITY[raw] or 0) > (SEVERITY[previous] or 0) then
+    return raw  -- degrading: react at once
+  end
+  local band = bandOf(ranges, previous)
+  if band and value >= band.from - deadband and value <= band.to + deadband then
+    return previous  -- still inside the widened previous band: hold
+  end
+  return raw
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/smoothing.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/smoothing.lua
@@ -1,0 +1,59 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - needle damping                                             #
+---- #                                                                       #
+---- # Frame-rate independent exponential filter:                            #
+---- #   factor = 1 - exp(-dt / tau)                                         #
+---- # so the needle glides at the same speed whatever the refresh rate,     #
+---- # while the digital value updates instantly.                            #
+---- #                                                                       #
+---- # getTime() returns 10 ms ticks (get_tmr10ms); ALL time maths converts  #
+---- # explicitly to milliseconds - mixing the two units makes the first     #
+---- # step of every re-acquisition jump.                                    #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local exp = math.exp
+
+-- Damping option (0..9) -> filter time constant in milliseconds.
+-- 0 disables the filter (raw value), 4 (default) is ~160 ms.
+function M.tau(damping)
+  local d = tonumber(damping) or 4
+  if d <= 0 then return 0 end
+  if d > 9 then d = 9 end
+  return d * 40
+end
+
+function M.reset(widget)
+  widget.smooth.value = nil
+  widget.smooth.time = 0
+end
+
+function M.step(widget, target)
+  local sm = widget.smooth
+  if target == nil then
+    sm.value = nil
+    return nil
+  end
+  local tau = widget.config.tau or 160
+  if tau <= 0 then
+    sm.value = target
+    return target
+  end
+  local now = getTime() * 10           -- 10 ms ticks -> ms
+  if sm.value == nil then
+    sm.value = target
+    sm.time = now
+    return target
+  end
+  local dt = now - sm.time
+  if dt <= 0 then dt = 1 elseif dt > 1000 then dt = 1000 end
+  sm.time = now
+  sm.value = sm.value + (target - sm.value) * (1 - exp(-dt / tau))
+  return sm.value
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/telemetry.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/telemetry.lua
@@ -1,0 +1,457 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - telemetry engine                                           #
+---- #                                                                       #
+---- # Source resolution with metadata caching, value reading with cell      #
+---- # aggregation, battery state-of-charge, and the availability model:     #
+---- #   unset        - no source configured                                 #
+---- #   invalid      - source id does not resolve                           #
+---- #   valid        - fresh/current data                                   #
+---- #   stale        - value present but sensor not current (link alive)    #
+---- #   disconnected - telemetry link down (getRSSI() == 0)                 #
+---- #   unavailable  - no value at all                                      #
+---- #                                                                       #
+---- # getSourceValue() returns THREE values: value, current, fresh          #
+---- # (api_general.cpp:837). Telemetry values are already scaled by the     #
+---- # sensor precision, so `prec` is only needed for formatting.            #
+---- #                                                                       #
+---- # History comes from the radio's own <name>- / <name>+ sensors when     #
+---- # they exist (the same source the rest of the UI shows, and the one     #
+---- # the standard telemetry reset clears); the in-Lua tracker is the       #
+---- # fallback for sticks, channels and gvars.                             #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+-- TelemetryUnit enum -> display text (subset; see dataconstants.h)
+local UNIT_NAMES = {
+  [1] = "V", [2] = "A", [3] = "mA", [4] = "kts", [5] = "m/s", [6] = "ft/s",
+  [7] = "km/h", [8] = "mph", [9] = "m", [10] = "ft", [11] = "C", [12] = "F",
+  [13] = "%", [14] = "mAh", [15] = "W", [16] = "mW", [17] = "dB", [18] = "rpm",
+  [19] = "g", [20] = "deg", [21] = "rad", [22] = "ml", [23] = "floz",
+  [24] = "ml/min", [25] = "Hz", [26] = "ms", [27] = "us", [28] = "km",
+  [29] = "dBm",
+}
+
+M.CELLS_LOWEST, M.CELLS_TOTAL, M.CELLS_AVERAGE = 1, 2, 3
+M.BATTERY_OFF, M.BATTERY_LIPO, M.BATTERY_LIION = 1, 2, 3
+
+-- F-9 retry policy: a telemetry source that is ABSENT at boot (the sensor
+-- not yet discovered - the normal case, telemetry arrives seconds after the
+-- widget) is re-resolved from refresh() at most once per second, for at most
+-- 30 attempts. Beyond that the source is treated as resolved-absent: a
+-- genuinely missing source must not rescan the 60-sensor table forever.
+local RESOLVE_RETRY_TICKS = 100     -- 1 s (getTime() counts 10 ms ticks)
+local MAX_RESOLVE_RETRIES = 30
+
+function M.unitName(unit)
+  return UNIT_NAMES[unit] or ""
+end
+
+-- getFieldInfo can return names starting with a stray invalid byte on some
+-- firmware versions (GaugeRotary lib_widget_tools cleanInvalidChar).  Do not
+-- confuse that firmware defect with UTF-8: every valid non-ASCII character
+-- also starts above 127.  Strip only bytes that cannot begin a valid UTF-8
+-- sequence; preserve an intact 2/3/4-byte character such as "É" or "温".
+local function validUtf8At(s, i)
+  local b1 = string.byte(s, i)
+  if not b1 then return false end
+  if b1 < 0x80 then return true end
+
+  local b2, b3, b4 = string.byte(s, i + 1), string.byte(s, i + 2),
+                      string.byte(s, i + 3)
+  local function cont(b) return b and b >= 0x80 and b <= 0xBF end
+  if b1 >= 0xC2 and b1 <= 0xDF then
+    return cont(b2)
+  elseif b1 == 0xE0 then
+    return b2 and b2 >= 0xA0 and b2 <= 0xBF and cont(b3)
+  elseif (b1 >= 0xE1 and b1 <= 0xEC) or (b1 >= 0xEE and b1 <= 0xEF) then
+    return cont(b2) and cont(b3)
+  elseif b1 == 0xED then
+    return b2 and b2 >= 0x80 and b2 <= 0x9F and cont(b3)
+  elseif b1 == 0xF0 then
+    return b2 and b2 >= 0x90 and b2 <= 0xBF and cont(b3) and cont(b4)
+  elseif b1 >= 0xF1 and b1 <= 0xF3 then
+    return cont(b2) and cont(b3) and cont(b4)
+  elseif b1 == 0xF4 then
+    return b2 and b2 >= 0x80 and b2 <= 0x8F and cont(b3) and cont(b4)
+  end
+  return false
+end
+
+local function cleanName(name)
+  if type(name) ~= "string" then return "" end
+  local n = string.byte(name, 1)
+  while n and n >= 0x80 and not validUtf8At(name, 1) do
+    name = string.sub(name, 2)
+    n = string.byte(name, 1)
+  end
+  return name
+end
+M.cleanName = cleanName
+
+-- Timer sources are the contiguous "timer" family (api_general.cpp:415).
+-- Detect them by id, never by name: T1/T2/T3 are common TEMPERATURE sensor
+-- labels, and telemetry sensors always carry a unit while timers do not.
+local timerBase = nil
+local function resolveTimerBase()
+  if timerBase ~= nil then return timerBase end
+  if type(getSourceIndex) == "function" then
+    timerBase = getSourceIndex("timer1") or false
+  else
+    timerBase = false
+  end
+  return timerBase
+end
+
+local function isTimerSource(id, name, isTelemetry)
+  if isTelemetry then return false end
+  local base = resolveTimerBase()
+  if base and id >= base and id <= base + 2 then return true end
+  if type(name) ~= "string" then return false end
+  return string.sub(name, 1, 5) == "timer" or name == "tx-time"
+end
+
+-- Sensor precision AND index are not exposed by getFieldInfo; look them up
+-- once, together, through the model sensor table. MAX_SENSORS is exposed to
+-- Lua (40/60/99 depending on the target) - scanning a hard-coded 32 misses
+-- sensors on big radios. The index (0-based, the same space as
+-- model.getSensor(i)) is what model.resetSensor(sensor) expects - it is NOT
+-- a MIXSRC id.
+--
+-- Each model.getSensor(i) call builds a fresh Lua table on the radio, so a
+-- 60-sensor scan is pure allocation, and the name -> {prec, index} mapping
+-- is MODEL data. The cache is therefore scoped to the WIDGET: the module
+-- table is shared for the whole radio session, and a module-level cache
+-- survived a model change and handed the next model a stale index - which
+-- model.resetSensor() then reset, destroying data on the model being flown
+-- (Tanda 6 F-6). resolveSource() only re-runs when the source changes, so
+-- the per-widget cache still avoids the repeated scan, with none of the
+-- cross-model hazard (review §B.4). Only HITS are cached: a sensor not yet
+-- connected must be re-scanned once it appears, so a miss is never cached.
+local function findSensor(widget, name)
+  if type(model) ~= "table" or type(model.getSensor) ~= "function" then
+    return nil, nil
+  end
+  local cache = widget.sensorCache
+  if cache then
+    local hit = cache[name]
+    if hit then return hit.prec, hit.index end
+  end
+  local count = tonumber(MAX_SENSORS) or 60
+  for i = 0, count - 1 do
+    local sn = model.getSensor(i)
+    if sn and sn.name == name then
+      cache = cache or {}
+      widget.sensorCache = cache
+      cache[name] = { prec = sn.prec, index = i }
+      return sn.prec, i
+    end
+  end
+  return nil, nil
+end
+
+-- Resolve and cache source metadata. Only does work when the source changed
+-- OR the previous resolution is still pending (F-9). A telemetry sensor
+-- that is absent at boot is the normal state - refresh() re-enters this
+-- throttled until getFieldInfo() answers, so name/unit/precision/preset,
+-- the -/+ siblings and the NO LINK vs NO DATA distinction all appear with
+-- the sensor, not before it.
+function M.resolveSource(widget)
+  local id = (widget.config and widget.config.source) or 0
+  local s = widget.source
+  if s.id == id and s.resolved then return s end
+  s.id = id
+  s.name = ""
+  s.unit = nil
+  s.unitName = ""
+  s.isTelemetry = false
+  s.isTimer = false
+  s.prec = nil
+  s.sensorIndex = nil
+  s.minId = nil
+  s.maxId = nil
+  s.cells = nil
+  s.resolved = false
+  if id and id > 0 then
+    local info = getFieldInfo(id)
+    if info then
+      s.name = cleanName(info.name or "")
+      s.unit = info.unit
+      s.unitName = M.unitName(info.unit)
+      -- tx-voltage is not a telemetry source, but the official Value widget
+      -- appends "V" to it (value.cpp MIXSRC_TX_VOLTAGE case)
+      if s.name == "tx-voltage" then s.unitName = "V" end
+      s.isTelemetry = (info.unit ~= nil)
+      s.isTimer = isTimerSource(id, s.name, s.isTelemetry)
+      if s.isTelemetry then
+        s.prec, s.sensorIndex = findSensor(widget, s.name)
+        -- the radio already tracks per-sensor min/max as sibling sources
+        local lo = getFieldInfo(s.name .. "-")
+        local hi = getFieldInfo(s.name .. "+")
+        s.minId = lo and lo.id or nil
+        s.maxId = hi and hi.id or nil
+      end
+      s.resolved = true
+      s.retries = nil
+      s.retryAt = nil
+      -- Generation counter. app.configure() derives the unit text, the name,
+      -- the Auto preset scale, the precision and the whole layout from the
+      -- fields above, and it only runs from update() - which the firmware
+      -- calls when the OPTIONS change, not periodically (widget.h:109). A
+      -- source that resolves LATE, from the retry in M.refresh below, would
+      -- therefore leave every derived value stale. app.refresh watches this
+      -- counter and reconfigures once when it moves.
+      --
+      -- Bumped ONLY on a real resolution: a failed retry repopulates
+      -- nothing, and the retries-exhausted latch in the else branch resolves
+      -- the source to "absent", which changes nothing either.
+      s.gen = (s.gen or 0) + 1
+    else
+      -- Not resolved yet: retry on later refreshes, but bounded so a
+      -- genuinely absent source does not rescan forever (Tanda 6 F-9).
+      s.retries = (s.retries or 0) + 1
+      s.resolved = (s.retries >= MAX_RESOLVE_RETRIES)
+    end
+  else
+    -- "no source" is a resolved state
+    s.resolved = true
+  end
+  return s
+end
+
+-- --------------------------------------------------------------- reading --
+
+local function setNoData(data, availability)
+  data.availability = availability
+  data.value = nil
+  data.displayValue = data.lastValue
+  data.state = nil
+  data.fresh = false
+end
+
+-- Aggregate a CELLS table according to the configured mode.
+-- getSourceValue returns one entry per cell, already in volts
+-- (api_general.cpp luaPushCells: values[i] * 0.01).
+local function aggregateCells(t, mode)
+  local total, count, lowest = 0, 0, nil
+  for i = 1, #t do
+    local v = t[i]
+    if type(v) == "number" then
+      total = total + v
+      count = count + 1
+      if lowest == nil or v < lowest then lowest = v end
+    end
+  end
+  if count == 0 then return nil, 0 end
+  if mode == M.CELLS_TOTAL then return total, count end
+  if mode == M.CELLS_AVERAGE then return total / count, count end
+  return lowest, count
+end
+M.aggregateCells = aggregateCells
+
+-- Latch the cell count on the first valid reading: a pack sags under load, so
+-- re-deriving it later would step the scale down mid-flight.
+local function latchCells(widget, value)
+  local s = widget.source
+  if s.cells then return s.cells end
+  local chem = (widget.config.battery == M.BATTERY_LIION) and "liion" or "lipo"
+  s.cells = widget.mods.presets.cellCount(value, chem)
+  return s.cells
+end
+M.latchCells = latchCells
+
+-- Returns true only when at least one sibling actually produced a number:
+-- both ids can resolve yet read nil for a while (sensor just appeared, no
+-- samples yet), and treating that as success permanently disables the
+-- trackHistory() fallback below (AUDIT.md P1-9).
+local function readHistorySiblings(widget)
+  local s, h = widget.source, widget.history
+  if not s.minId and not s.maxId then return false end
+  local lo = s.minId and getSourceValue(s.minId) or nil
+  local hi = s.maxId and getSourceValue(s.maxId) or nil
+  local gotAny = false
+  local changed = false
+  if type(lo) == "number" then
+    gotAny = true
+    if h.min == nil or lo < h.min or h.min < lo then
+      h.min, changed = lo, true
+    end
+  end
+  if type(hi) == "number" then
+    gotAny = true
+    if h.max == nil or hi < h.max or h.max < hi then
+      h.max, changed = hi, true
+    end
+  end
+  if changed then h.gen = (h.gen or 0) + 1 end
+  return gotAny
+end
+
+-- True when the reading is already a single cell's voltage: a Cels source
+-- aggregated as Lowest or Average is per-cell after aggregateCells(), so the
+-- battery block must NOT divide by the cell count again (Tanda 6 F-2 - the
+-- default Lowest configuration read 0 % at 3.85 V/cell because the per-cell
+-- aggregate was divided by four a second time).
+local function isPerCellReading(cfg, wasCells)
+  return wasCells and cfg.cells ~= M.CELLS_TOTAL
+end
+
+-- The radio's <name>-/<name>+ siblings track the RAW per-item sensor value.
+-- That is only the same quantity as the displayed value when neither
+-- transform below is active; otherwise the units silently mismatch (a
+-- percentage dial with volt history, or a pack total with a per-cell
+-- extreme) - api_general.cpp documents Cels+/Cels- as always a single
+-- cell's value, never the pack total or average (AUDIT.md P0-7). This is
+-- deliberately STRICTER than isPerCellReading(): Average is also a per-cell
+-- reading for the battery math, but its MEAN is not the siblings' extreme,
+-- so only Lowest may trust them.
+local function historyTrustworthy(cfg, wasCells)
+  if cfg.battery and cfg.battery ~= M.BATTERY_OFF then return false end
+  if wasCells then return cfg.cells == M.CELLS_LOWEST end
+  return true
+end
+M.historyTrustworthy = historyTrustworthy
+
+-- Fallback tracker: reached whenever the sibling history cannot be trusted
+-- for this reading's units, not only when the source has no sibling sensors.
+local function trackHistory(widget, value)
+  local h = widget.history
+  local changed = false
+  if h.min == nil then
+    h.min, h.max = value, value
+    changed = true
+  else
+    if value < h.min then h.min, changed = value, true end
+    if value > h.max then h.max, changed = value, true end
+  end
+  if changed then h.gen = (h.gen or 0) + 1 end
+end
+
+-- Read the source and update widget.data.
+function M.refresh(widget)
+  local data = widget.data
+  local src = widget.source
+  local cfg = widget.config
+
+  if not src.id or src.id == 0 then
+    data.availability = "unset"
+    data.value = nil
+    data.displayValue = nil
+    data.state = nil
+    data.fresh = false
+    return
+  end
+
+  -- F-9: a source that was absent at boot is still unresolved - keep
+  -- re-resolving it, throttled, until getFieldInfo() answers. The old
+  -- unconditional resolved=true latch lost the sensor forever (name, unit,
+  -- precision, preset, siblings, NO LINK vs NO DATA).
+  if not src.resolved then
+    local now = getTime()
+    if now - (src.retryAt or 0) >= RESOLVE_RETRY_TICKS then
+      src.retryAt = now
+      src = M.resolveSource(widget)
+    end
+  end
+
+  local value, current, fresh = getSourceValue(src.id)
+
+  if value == nil then
+    if src.isTelemetry and getRSSI() == 0 then
+      setNoData(data, "disconnected")
+    else
+      setNoData(data, "unavailable")
+    end
+    return
+  end
+
+  local wasCells = false
+  if type(value) == "table" then
+    wasCells = true
+    local aggregate, count = aggregateCells(value, cfg.cells or M.CELLS_LOWEST)
+    if aggregate == nil then
+      -- non-numeric tables (GPS, date/time) are not gauge readings
+      setNoData(data, "unavailable")
+      return
+    end
+    value = aggregate
+    if count > 0 then src.cells = src.cells or count end
+  end
+
+  if type(value) ~= "number" then
+    setNoData(data, "unavailable")
+    return
+  end
+
+  -- A non-finite reading is not a value, and an instrument must not pretend
+  -- to know: NaN / +-inf are "no data", the same as no reading at all.
+  --
+  -- This is a containment guard, not a formality. The three are contagious:
+  -- geometry.normalize maps NaN to NaN (neither comparison in clamp() is
+  -- true), smoothing.step turns +-inf into NaN on its SECOND frame
+  -- (inf - inf), and the NaN then arrives at lvgl.set as an arc endAngle,
+  -- where the binding's luaL_checkinteger raises "number has no integer
+  -- representation" - the widget disables itself for the session. format.lua
+  -- already refuses to print a NaN (M.NO_VALUE); this is the same refusal
+  -- applied to the geometry, at the one gate every reading passes through.
+  if value ~= value or value == math.huge or value == -math.huge then
+    setNoData(data, "unavailable")
+    return
+  end
+
+  if src.isTelemetry and not current then
+    setNoData(data, "stale")
+    return
+  end
+
+  -- A pack voltage only tells you something once you know how many cells it
+  -- has; latch the count from the first reading (see latchCells).
+  if widget.autoCells and not src.cells then
+    latchCells(widget, value)
+  end
+
+  -- Battery mode: show state of charge instead of raw volts.
+  if cfg.battery and cfg.battery ~= M.BATTERY_OFF then
+    local chem = (cfg.battery == M.BATTERY_LIION) and "liion" or "lipo"
+    local cells = latchCells(widget, value)
+    -- A Cels source aggregated as Lowest/Average is ALREADY per-cell volts:
+    -- dividing again turns ~55 % into ~0 % (Tanda 6 F-2). Only pack-total
+    -- readings - and non-table sources like RxBt, which report the pack
+    -- directly - need the /count conversion.
+    local perCell = value
+    if not isPerCellReading(cfg, wasCells) and cells > 0 then
+      perCell = value / cells
+    end
+    local percent = widget.mods.presets.percentFromCell(perCell, chem)
+    if percent then
+      value = percent
+    end
+  end
+
+  data.availability = "valid"
+  data.value = value
+  data.displayValue = value
+  data.lastValue = value
+  data.fresh = (fresh == true)
+
+  local prev = data.state
+  data.state = widget.mods.ranges.determineState(value, widget.ranges, prev,
+                                                 widget.deadband)
+
+  local trusted = historyTrustworthy(cfg, wasCells) and readHistorySiblings(widget)
+  if not trusted then
+    trackHistory(widget, value)
+  end
+end
+
+-- Clear the tracked history (source/range change, or the reset switch).
+function M.resetHistory(widget)
+  widget.history.min = nil
+  widget.history.max = nil
+  widget.history.gen = (widget.history.gen or 0) + 1
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/theme.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/theme.lua
@@ -1,0 +1,637 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Gauge Pro - design tokens and text metrics                             #
+---- #                                                                       #
+---- # Single source of truth for colour, opacity, spacing and typography.   #
+---- # ui_core/dial_renderer/bar never name a raw constant; they ask here.  #
+---- #                                                                       #
+---- # Colours are theme roles (api_colorlcd.cpp COLOR_THEME_*) so the gauge #
+---- # follows dark / light / high-contrast themes. The only literal is RED: #
+---- # the firmware exposes no "critical" theme role.                        #
+---- #                                                                       #
+---- # Text metrics: lcd.sizeText() reports the font cell (including         #
+---- # leading), not the ink box, and the numbers differ per screen scale.   #
+---- # Rather than hard-coding per-font correction tables (which are         #
+---- # resolution specific), we                                              #
+---- #   * memoize the measurement (it never changes at runtime), and        #
+---- #   * let LVGL align text horizontally inside a label of known width    #
+---- #     (align = CENTER / RIGHT) instead of positioning by measured width.#
+---- # The reported height is >= the ink height, so using it for fitting is  #
+---- # conservative - text never overflows its region.                       #
+---- #                                                                       #
+---- # MEASURING CONTRACT (Tanda 6 F-4): M.textWidth is memoized and         #
+---- # therefore BOUNDED - it may only be called from layout/build paths,    #
+---- # over the fixed set of strings one configuration can produce. The      #
+---- # renderers must never measure a LIVE string through it: at high        #
+---- # precision the value string changes every frame, and each new string   #
+---- # would become a permanent entry in a cache shared by every gauge on    #
+---- # the card. M.measureWidth is the renderers' entry: exact, deliberately #
+---- # NOT memoized, one lcd.sizeText call per call.                         #
+---- #                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #########################################################################
+
+local M = {}
+
+local floor, min, max = math.floor, math.min, math.max
+
+-- Font flags: the firmware's etcxcst constants are the font index << 8
+-- (radio/src/gui/colorlcd/fonts.h FONT_INDEX). Ordered small -> large.
+M.FONTS = {
+  XXS = TINSIZE,
+  XS  = SMLSIZE,
+  S   = STDSIZE,
+  M   = MIDSIZE,
+  L   = DBLSIZE,
+  XL  = XLSIZE,
+  XXL = XXLSIZE,
+}
+
+-- Ordered candidate ramp used by the auto-fit search (largest first).
+-- STDSIZE is deliberately IN the ramp: the old M(24) -> XS(13) jump skipped
+-- the 16 px step, so a chord that barely missed 24 px threw the value down to
+-- 13 px (AUDIT.md P3-4; P0-2's value clearance narrows the chord at 200x160).
+--
+-- Built by FILTERING, not by literal indexing: a firmware that does not
+-- define one of these constants (e.g. XXLSIZE on a target that has no
+-- double-size fonts) must degrade to a shorter ramp, never leave a HOLE.
+-- #RAMP keeps reporting the full length otherwise, so fitFont walks into
+-- fontHeight(nil) -> heightCache[nil] = h raises `table index is nil`
+-- (Tanda 6 F-10): a crash on the first layout pass, and the widget
+-- permanently disables itself.
+local RAMP_ORDER = { "XXL", "XL", "L", "M", "S", "XS", "XXS" }
+M.RAMP = {}
+for i = 1, #RAMP_ORDER do
+  local f = M.FONTS[RAMP_ORDER[i]]
+  if f ~= nil then M.RAMP[#M.RAMP + 1] = f end
+end
+assert(#M.RAMP > 0, "GaugePro: firmware exposes no usable font constants")
+
+-- TWO CHANNELS, NEVER ONE (Tanda 8 §3). A gauge has to say two different
+-- things at once, and they have incompatible requirements:
+--
+--   STATUS - the arc, the rail/section bands, the threshold marks, the badge.
+--            Large, peripheral, read as a blob of colour in ~200 ms with the
+--            pilot's eyes on the aircraft. Hue is the right channel here.
+--   DATA   - the value, unit, source name, min/max. Read as SHAPES. Legibility
+--            beats identity, and a hue that must survive an unknown background
+--            buys nothing you can actually read.
+--
+-- Every real instrument splits them this way: an airspeed indicator has green,
+-- yellow and red arcs ON THE DIAL FACE and plain white numerals. Colouring the
+-- number is what a dashboard does; colouring the scale is what an instrument
+-- does. Before Tanda 8 the status colour drove BOTH, which is why a role
+-- chosen for a button background ended up as the value's text colour.
+--
+-- The one deliberate exception is CRITICAL, where alarm outranks neutrality.
+M.color = {
+  -- The three status colours are FIXED, not theme roles. The reasoning that
+  -- already justified a literal for `crit` - EdgeTX has no "critical" role -
+  -- applies just as well to "good" and "warning": the role vocabulary is a UI
+  -- vocabulary (PRIMARY* is text, SECONDARY* is chrome, ACTIVE is the
+  -- background of a CHECKED control, WARNING is warning LABEL TEXT), and it
+  -- has no notion of instrument state.
+  --
+  -- This used to be COLOR_THEME_ACTIVE, which is #ffde00 on the stock theme
+  -- and scores 1.13:1 against the stock screen background - the normal state,
+  -- arc and value alike, was effectively invisible on a stock radio. It
+  -- measured 9.87:1 on a dark theme, which is why every render in this repo
+  -- looked right for four review rounds.
+  --
+  -- A fixed colour has no theme author looking after it, so each one is
+  -- chosen to clear the WCAG 1.4.11 non-text floor (3:1) against BOTH
+  -- reference backgrounds - stock light #e4eef2 and a dark theme #303030.
+  -- That constrains relative luminance to [0.189, 0.247], a window only 0.058
+  -- wide, and 3.35:1 is the best ANY colour can do on both at once. All three
+  -- land within 0.05 of that optimum:
+  --
+  --        light      dark
+  --   #209058  3.35:1  3.35:1   normal    (was 1.13:1)
+  --   #c86000  3.34:1  3.35:1   warning   (stock WARNING role: 2.76:1 on dark)
+  --   #ff0000  3.39:1  3.30:1   critical  (unchanged - already near optimal)
+  --
+  -- Equal luminance by construction, so no state shouts louder than another by
+  -- accident and the three differ in HUE alone - which is exactly how dial
+  -- arcs are drawn. It also means hue is the ONLY separator, so the badge text
+  -- (renderer.stateText) is not decoration: see the note on `warn` below.
+  accent  = lcd.RGB(0x20, 0x90, 0x58),
+  -- Fixed too, and for a reason beyond contrast. On the stock theme
+  -- COLOR_THEME_WARNING is #e00000 - a red 53 perceptual units from critical's
+  -- #ff0000, i.e. THE SAME COLOUR to the eye, which wasted the hue channel
+  -- entirely. This amber sits 213 units away. The cost is real and worth
+  -- naming: a theme author who picked a warning colour no longer sees it here.
+  warn    = lcd.RGB(0xc8, 0x60, 0x00),
+  -- An lcd.RGB literal rather than the RED constant, though they are the same
+  -- #ff0000: lcd.getColor() returns NIL for the fixed colour indices
+  -- (api_colorlcd.cpp:968 - only RGB flags and the 14 theme indices resolve),
+  -- so RED could not be decoded by labelOn() below.
+  crit    = lcd.RGB(0xff, 0x00, 0x00),
+
+  -- ---- DATA channel: theme roles, never the status colour ----------------
+  -- PRIMARY1 is the theme's own ink - "label text" in the theme vocabulary,
+  -- 17.81:1 on the stock background, and whatever a dark theme's author chose
+  -- in its place. The value is the one thing on the widget that must stay
+  -- readable in every state, so it gets the role whose whole job is that.
+  value   = COLOR_THEME_PRIMARY1,
+  -- The badge label picks between these two by the fill's luminance
+  -- (M.labelOn): PRIMARY1/PRIMARY2 are a PAIR in the theme vocabulary - ink
+  -- on the screen background, and ink on chrome - so a theme that inverts one
+  -- inverts the other, and the badge follows without being told.
+  inkDark = COLOR_THEME_PRIMARY1,
+  inkLite = COLOR_THEME_PRIMARY2,
+
+  needle  = COLOR_THEME_PRIMARY1,    -- the needle NEVER follows the state
+                                     -- colour (owner request): a fixed,
+                                     -- always-legible tone against every
+                                     -- band colour, including the green
+                                     -- normal state above, and both themes
+  rail    = COLOR_THEME_SECONDARY1,  -- track + rail base (used with opacity)
+  tick    = COLOR_THEME_SECONDARY1,  -- scale ticks: the LIGHTER role, so 1 px
+                                     -- marks read on dark themes (review P-C)
+  label   = COLOR_THEME_SECONDARY1,
+  muted   = COLOR_THEME_DISABLED,
+  history = COLOR_THEME_SECONDARY1,
+}
+
+M.opacity = {
+  full     = 255,
+  rail     = 90,    -- inactive track: ~35% - a crisper silhouette that still
+                    -- never competes with the value arc (review P2-9)
+  railBand = 200,   -- reference rail bands (Rail mode): drawn at reduced
+                    -- opacity so the value arc - and with it the critical
+                    -- red - stays the foreground (review P-E)
+  railBandCrit = 160, -- one step dimmer, applied ONLY while the state is
+                    -- critical (renderer.applyColors): at 200 the passive
+                    -- amber band was the highest-luminance element on the
+                    -- ring, competing with the full-red arc/text it is
+                    -- supposed to sit behind (Tanda 5 review 3.6)
+  ghost    = 110,   -- peak-hold segment
+  tickMinor = 110,  -- Fine Ticks reference grid: visible but subordinate
+  tickMajor = 145,  -- endpoints, fifths and exact thresholds read first
+  muted    = 120,   -- whole gauge when data is not live
+  pulse    = 150,   -- critical pulse trough
+}
+
+-- Logical spacing steps; always passed through px().
+M.space = { xs = 2, sm = 4, md = 6, lg = 10 }
+
+M.ratio = {
+  unitToValue     = 0.55,  -- unit font relative to the value font
+  trackToRadius   = 0.14,
+  railToTrack     = 0.34,
+  -- Needle keeps the track as the quiet reference and the active arc as a
+  -- subordinate position cue. Arc style does not consume this ratio: its arc
+  -- remains the full track thickness because it is the only value geometry.
+  needleArcToTrack = 0.62,
+  -- Exact Threshold marks cross the track and extend slightly towards the
+  -- ticks. The layout clamps the resulting physical lip to 1..2 pixels.
+  thresholdLipToTrack = 0.15,
+  needleWidth     = 0.055, -- half-width of the needle base, relative to radius
+  -- Three-part taper (owner request, Tanda 5): two steps (thick body ->
+  -- thin tip, review P-A) read as a paddle with a toothpick glued to the
+  -- end - the width more than halves in one jump with almost no blend.
+  -- A middle segment splits that single big step into two smaller ones.
+  needleBodyReach = 0.30,  -- short base establishes direction without reading
+                           -- as a second hub
+  needleMidReach  = 0.66,  -- longer mid/tip transitions make taper visible
+  -- 0.62 looked right on paper but `floor(needleHalf * ratio)` collapses
+  -- mid onto the tip's width at the canonical 200x160 base (needleHalf=3:
+  -- floor(3*0.62)=1, same as the tip) - the 3rd step silently disappeared
+  -- at the most common size. 0.7 clears that floor (floor(3*0.7)=2).
+  needleMidToHalf = 0.68,  -- mid half-width relative to the BASE half-width
+  needleTipToHalf = 0.32,  -- tip half-width relative to the base half-width;
+                           -- layout still enforces the legible 2 px minimum
+  pivotRadius     = 0.08,  -- one physical step smaller at the reference size
+}
+
+-- Physical size helper: LCD_SCALE is 0.8 / 1.0 / 1.375 for 320 / 480 / 800 px
+-- wide screens (etx_lv_theme.h), so px() keeps proportions identical.
+function M.px(value)
+  return max(1, floor(value * (lvgl.LCD_SCALE or 1) + 0.5))
+end
+
+-- ---------------------------------------------------------------- metrics --
+
+local widthCache = {}
+local heightCache = {}
+
+-- Height of a font, measured once. Used for fitting and row heights.
+function M.fontHeight(font)
+  local h = heightCache[font]
+  if h then return h end
+  local _, measured = lcd.sizeText("8", font)
+  h = (type(measured) == "number" and measured > 0) and measured or 16
+  heightCache[font] = h
+  return h
+end
+
+-- Width of a string, memoized per (font, text). BOUNDED by contract: only
+-- called from layout / build paths over the fixed string set one
+-- configuration produces (see the header). NEVER call this with a live
+-- value string - that is what M.measureWidth is for.
+function M.textWidth(text, font)
+  local byFont = widthCache[font]
+  if not byFont then
+    byFont = {}
+    widthCache[font] = byFont
+  end
+  local w = byFont[text]
+  if not w then
+    w = lcd.sizeText(text, font) or 0
+    byFont[text] = w
+  end
+  return w
+end
+
+-- Exact width of a string, deliberately NOT memoized: one lcd.sizeText call
+-- per call, no cache write. The renderers' entry for the LIVE value string
+-- (anchorUnit): exact like textWidth but incapable of growing the shared
+-- cache one entry per frame (Tanda 6 F-4).
+function M.measureWidth(text, font)
+  return lcd.sizeText(text, font) or 0
+end
+
+-- Largest font from `candidates` whose height fits `available`.
+-- Falls back to the smallest candidate.
+function M.fitFont(candidates, available)
+  for i = 1, #candidates do
+    if M.fontHeight(candidates[i]) <= available then return candidates[i] end
+  end
+  return candidates[#candidates]
+end
+
+-- Font one step smaller in the ramp (used for the unit next to the value).
+-- The unit never lands on STDSIZE: a 24 px value keeps its 13 px unit (the
+-- ~0.55 ratio of the Tanda-4 design), even though STDSIZE is a valid VALUE
+-- font in the ramp (P0-2 / AUDIT P3-4).
+function M.smallerFont(font, steps)
+  steps = steps or 1
+  for i = 1, #M.RAMP do
+    if M.RAMP[i] == font then
+      local j = i + steps
+      while j <= #M.RAMP and M.RAMP[j] == M.FONTS.S do j = j + 1 end
+      if j > #M.RAMP then j = #M.RAMP end
+      return M.RAMP[j]
+    end
+  end
+  return font
+end
+
+-- ----------------------------------------------------------------- states --
+
+-- Colour for a semantic state key. `accent` overrides the normal colour when
+-- the user picked one (Accent option); nil keeps the theme role.
+function M.stateColor(key, accent, palette)
+  if palette then
+    if key == "warning" then return palette.warning end
+    if key == "critical" then return palette.critical end
+    if key == "muted" then return palette.muted or M.color.muted end
+    return palette.normal or accent or M.color.accent
+  end
+  if key == "warning" then return M.color.warn end
+  if key == "critical" then return M.color.crit end
+  if key == "muted" then return M.color.muted end
+  return accent or M.color.accent
+end
+
+-- ---------------------------------------------------------------- luminance --
+
+-- The RGB behind a colour flag, or nil if the firmware will not say.
+--
+-- lcd.getColor exists (api_colorlcd.cpp:956, since 2.3.11) and returns the
+-- RGB565 value in the HIGH 16 bits with RGB_FLAG set. Its guard resolves RGB
+-- flags and the fourteen THEME indices only, so a FIXED literal (RED, GREEN,
+-- WHITE...) comes back nil - which is why this widget's own status colours are
+-- lcd.RGB literals: those carry RGB_FLAG and always resolve.
+--
+-- An RGB flag can be decoded without calling anything, so the API is only
+-- consulted for theme roles. Nothing here is load-bearing: every caller has a
+-- defined answer for nil.
+local function resolveColor(flag)
+  if type(flag) ~= "number" then return nil end
+  local v = flag
+  if (v & 0x8000) == 0 then
+    if type(lcd) ~= "table" or type(lcd.getColor) ~= "function" then
+      return nil
+    end
+    local ok, got = pcall(lcd.getColor, flag)
+    if not ok or type(got) ~= "number" then return nil end
+    v = got
+  end
+  return v
+end
+M.resolveColor = resolveColor
+
+local function rgbOf(flag)
+  local v = resolveColor(flag)
+  if not v then return nil end
+  local c = (v >> 16) & 0xFFFF
+  return (c & 0xF800) >> 8, (c & 0x07E0) >> 3, (c & 0x001F) << 3
+end
+M.rgbOf = rgbOf
+
+local function channel(c)
+  c = c / 255
+  if c <= 0.04045 then return c / 12.92 end
+  return ((c + 0.055) / 1.055) ^ 2.4
+end
+
+-- WCAG 2.x relative luminance, 0..1.
+local function luminance(r, g, b)
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+end
+M.luminance = luminance
+
+-- Contrast and distance are analysis signals, not color-replacement rules.
+-- A theme or custom palette whose colors are close keeps the exact authored
+-- colors; bar_style uses these measurements to request redundant structure.
+function M.contrastRatio(a, b)
+  local ar, ag, ab = rgbOf(a)
+  local br, bg, bb = rgbOf(b)
+  if not ar or not br then return nil end
+  local la, lb = luminance(ar, ag, ab), luminance(br, bg, bb)
+  local hi, lo = max(la, lb), (la < lb) and la or lb
+  return (hi + 0.05) / (lo + 0.05)
+end
+
+function M.colorDistance(a, b)
+  local ar, ag, ab = rgbOf(a)
+  local br, bg, bb = rgbOf(b)
+  if not ar or not br then return nil end
+  local dr, dg, db = ar - br, ag - bg, ab - bb
+  return math.sqrt(dr * dr + dg * dg + db * db)
+end
+
+-- A stable signature uses resolved RGB values for theme roles. Theme flags
+-- themselves do not change when the pilot changes theme; lcd.getColor does.
+function M.colorSignature(colors)
+  local parts = {}
+  for i = 1, #colors do
+    local flag = colors[i]
+    parts[i] = tostring(resolveColor(flag) or flag or "nil")
+  end
+  return table.concat(parts, ":")
+end
+
+local function inverseChannel(c)
+  if c <= 0.0031308 then return c * 12.92 * 255 end
+  return (1.055 * (c ^ (1 / 2.4)) - 0.055) * 255
+end
+
+-- Full dichromacy matrices from Machado et al. They are used only while a
+-- palette is resolved (configure/theme change), never in the frame loop.
+-- Measuring the simulated separation lets Auto add a redundant outline/head
+-- when two authored severity colours collapse for a pilot with a common
+-- colour-vision deficiency. The authored colours themselves remain untouched.
+local CVD = {
+  protanopia = {
+    0.152286, 1.052583, -0.204868,
+    0.114503, 0.786281, 0.099216,
+    -0.003882, -0.048116, 1.051998,
+  },
+  deuteranopia = {
+    0.367322, 0.860646, -0.227968,
+    0.280085, 0.672501, 0.047413,
+    -0.011820, 0.042940, 0.968881,
+  },
+  tritanopia = {
+    1.255528, -0.076749, -0.178779,
+    -0.078411, 0.930809, 0.147602,
+    0.004733, 0.691367, 0.303900,
+  },
+}
+
+local function cvdRgb(color, matrix)
+  local r, g, b = rgbOf(color)
+  if not r then return nil end
+  r, g, b = channel(r), channel(g), channel(b)
+  local rr = matrix[1] * r + matrix[2] * g + matrix[3] * b
+  local gg = matrix[4] * r + matrix[5] * g + matrix[6] * b
+  local bb = matrix[7] * r + matrix[8] * g + matrix[9] * b
+  rr, gg, bb = max(0, min(1, rr)), max(0, min(1, gg)), max(0, min(1, bb))
+  return inverseChannel(rr), inverseChannel(gg), inverseChannel(bb)
+end
+
+function M.colorVisionDistance(a, b, mode)
+  local matrix = CVD[mode]
+  if not matrix then return M.colorDistance(a, b) end
+  local ar, ag, ab = cvdRgb(a, matrix)
+  local br, bg, bb = cvdRgb(b, matrix)
+  if not ar or not br then return nil end
+  local dr, dg, db = ar - br, ag - bg, ab - bb
+  return math.sqrt(dr * dr + dg * dg + db * db)
+end
+
+-- Gamma-aware interpolation in linear-light space. Endpoints are returned
+-- byte-for-byte so choosing a custom color never silently edits it.
+function M.mixColor(a, b, t)
+  if t <= 0 then return a end
+  if t >= 1 then return b end
+  local ar, ag, ab = rgbOf(a)
+  local br, bg, bb = rgbOf(b)
+  if not ar or not br then return (t < 0.5) and a or b end
+  local r = inverseChannel(channel(ar) + (channel(br) - channel(ar)) * t)
+  local g = inverseChannel(channel(ag) + (channel(bg) - channel(ag)) * t)
+  local bl = inverseChannel(channel(ab) + (channel(bb) - channel(ab)) * t)
+  return lcd.RGB(floor(r + 0.5), floor(g + 0.5), floor(bl + 0.5))
+end
+
+-- The ink colour to print ON a filled swatch: whichever of the theme's two
+-- text roles contrasts more with the fill.
+--
+-- This is what makes a filled badge SELF-GROUNDING - its contrast is between
+-- the fill and its own label, both of which the widget controls - so it reads
+-- on a light theme, a dark theme, and a theme that ships a background.png
+-- photograph alike. No flat colour can promise that.
+--
+-- Memoized by BOTH the fill and the resolved theme inks. Theme role flags are
+-- stable numeric IDs while lcd.getColor(role) changes when the pilot switches
+-- theme. Caching by `fill` alone therefore returned a decision made for the
+-- previous theme until the Lua state was reloaded.
+local INK_CACHE_MAX = 32
+local inkCache, inkOrder = {}, {}
+function M.labelOn(fill, palette)
+  local fillResolved = resolveColor(fill)
+  local darkInk = (palette and palette.inkDark) or M.color.inkDark
+  local liteInk = (palette and palette.inkLite) or M.color.inkLite
+  local darkResolved = resolveColor(darkInk)
+  local liteResolved = resolveColor(liteInk)
+  local cacheKey = tostring(fill) .. ":" .. tostring(
+    (palette and palette.signature) or "default")
+  local cached = inkCache[cacheKey]
+  if cached and cached.fill == fillResolved and cached.dark == darkResolved
+     and cached.lite == liteResolved then
+    return cached.ink
+  end
+
+  local r, g, b = rgbOf(fillResolved)
+  local ink
+  if not r then
+    -- Unknowable fill: PRIMARY1 is the theme's own ink and the safer guess,
+    -- since a widget on a stock radio is drawn on a light background.
+    ink = darkInk
+  else
+    local lf = luminance(r, g, b)
+    local dr, dg, db = rgbOf(darkInk)
+    local lr, lg, lb = rgbOf(liteInk)
+    -- No theme information at all: 0.1791 is where black and white tie.
+    if not dr or not lr then
+      ink = (lf > 0.1791) and darkInk or liteInk
+    else
+      local function ratio(a, c)
+        local hi, lo = max(a, c), (a < c) and a or c
+        return (hi + 0.05) / (lo + 0.05)
+      end
+      ink = (ratio(lf, luminance(dr, dg, db)) >= ratio(lf, luminance(lr, lg, lb)))
+        and darkInk or liteInk
+    end
+  end
+  if not inkCache[cacheKey] then
+    if #inkOrder >= INK_CACHE_MAX then
+      local old = table.remove(inkOrder, 1)
+      inkCache[old] = nil
+    end
+    inkOrder[#inkOrder + 1] = cacheKey
+  end
+  inkCache[cacheKey] = {
+    fill = fillResolved, dark = darkResolved, lite = liteResolved, ink = ink,
+  }
+  return ink
+end
+
+function M.inkCacheStats()
+  return { entries = #inkOrder, maximum = INK_CACHE_MAX }
+end
+
+-- ----------------------------------------------------------------- gradient --
+
+-- Continuous critical -> warning -> normal ramp (Gradient colour mode),
+-- expressed on the normalized 0..1 position between the critical end (0) and
+-- the good end (1).
+--
+-- It interpolates between the THREE STATUS COLOURS rather than inventing its
+-- own endpoints. The old ramp was lcd.RGB(0xdf - g, g, 0): a straight line to
+-- #00df00, which is 1.16:1 against the stock background - the same defect as
+-- the old accent, confined to one mode. Anchoring the ends to colours that
+-- were already chosen for both backgrounds fixes the ends for free.
+--
+-- The MIDDLE is the part that needs work. Mixing amber into green passes
+-- through olive, and luminance is not linear in sRGB values, so intermediate
+-- mixes wander out of the [0.189, 0.247] window even though both endpoints sit
+-- inside it. A scale factor pulls any mix that drifts back to the edge of the
+-- window, which holds the whole ramp at >= 3.02:1 on both reference
+-- backgrounds - against 1.54:1 worst case before. Hue varies; brightness does
+-- not. That is how a dial's colour scale should behave anyway: no part of the
+-- ramp is allowed to shout louder than another.
+--
+-- The bounds are drawn in slightly from the true window so the RGB565
+-- quantisation the panel applies cannot push a step back out.
+local GRAD_LO, GRAD_HI = 0.198, 0.240
+local gradCache = {}
+
+local function gradAnchor(t)
+  local r1, g1, b1 = rgbOf(M.color.crit)
+  local r2, g2, b2 = rgbOf(M.color.warn)
+  local r3, g3, b3 = rgbOf(M.color.accent)
+  -- rgbOf cannot fail for these (lcd.RGB literals), but a nil here would
+  -- otherwise become an arithmetic error inside a render callback.
+  if not r1 or not r2 or not r3 then return nil end
+  local a, b, u
+  if t < 0.5 then
+    a, b, u = { r1, g1, b1 }, { r2, g2, b2 }, t * 2
+  else
+    a, b, u = { r2, g2, b2 }, { r3, g3, b3 }, (t - 0.5) * 2
+  end
+  return a[1] + (b[1] - a[1]) * u,
+         a[2] + (b[2] - a[2]) * u,
+         a[3] + (b[3] - a[3]) * u
+end
+
+function M.gradientColor(t)
+  if t < 0 then t = 0 elseif t > 1 then t = 1 end
+  local cached = gradCache[t]
+  if cached then return cached end
+  local r, g, b = gradAnchor(t)
+  if not r then return M.color.accent end
+  local l = luminance(r, g, b)
+  -- 1/2.2 undoes the display gamma well enough to land inside the window in
+  -- one step; the exact figure does not matter because the window is a band,
+  -- not a point.
+  local k
+  if l > GRAD_HI then k = (GRAD_HI / l) ^ (1 / 2.2)
+  elseif l < GRAD_LO then k = (GRAD_LO / l) ^ (1 / 2.2) end
+  if k then
+    r, g, b = r * k, g * k, b * k
+    if r > 255 then r = 255 end
+    if g > 255 then g = 255 end
+    if b > 255 then b = 255 end
+  end
+  local c = lcd.RGB(floor(r + 0.5), floor(g + 0.5), floor(b + 0.5))
+  gradCache[t] = c
+  return c
+end
+
+-- Palette-aware interpolation for bar faces. It is quantized and bounded:
+-- live values can only address `steps + 1` entries, and repeated palette or
+-- theme edits retain at most PALETTE_CACHE_MAX signatures. Classic delegates
+-- to the already approved calibrated ramp, keeping its pixels identical.
+local PALETTE_CACHE_MAX = 12
+local paletteCache, paletteOrder = {}, {}
+
+local function paletteBucket(signature)
+  local bucket = paletteCache[signature]
+  if bucket then return bucket end
+  if #paletteOrder >= PALETTE_CACHE_MAX then
+    local old = table.remove(paletteOrder, 1)
+    paletteCache[old] = nil
+  end
+  bucket = {}
+  paletteCache[signature] = bucket
+  paletteOrder[#paletteOrder + 1] = signature
+  return bucket
+end
+
+function M.paletteColor(palette, t, steps)
+  palette = palette or {
+    normal = M.color.accent, warning = M.color.warn,
+    critical = M.color.crit, signature = "classic", calibrated = true,
+  }
+  steps = floor(tonumber(steps) or 24)
+  if steps < 2 then steps = 2 elseif steps > 24 then steps = 24 end
+  if t < 0 then t = 0 elseif t > 1 then t = 1 end
+  local q = floor(t * steps + 0.5)
+  local signature = tostring(palette.signature or M.colorSignature{
+    palette.normal, palette.warning, palette.critical,
+  })
+  local bucket = paletteBucket(signature)
+  local key = steps * 100 + q
+  local cached = bucket[key]
+  if cached then return cached end
+
+  local qt = q / steps
+  local color
+  if q == 0 then color = palette.critical
+  elseif q == steps then color = palette.normal
+  elseif palette.calibrated then color = M.gradientColor(qt)
+  elseif qt <= 0.5 then color = M.mixColor(palette.critical,
+                                            palette.warning, qt * 2)
+  else color = M.mixColor(palette.warning, palette.normal, (qt - 0.5) * 2)
+  end
+  bucket[key] = color
+  return color
+end
+
+function M.paletteCacheStats()
+  local entries = 0
+  for _, bucket in pairs(paletteCache) do
+    for _ in pairs(bucket) do entries = entries + 1 end
+  end
+  return { signatures = #paletteOrder, entries = entries,
+           maximum = PALETTE_CACHE_MAX }
+end
+
+function M.clearPaletteCache()
+  paletteCache, paletteOrder = {}, {}
+end
+
+return M

--- a/sdcard/color/SCRIPTS/TOOLS/GaugeCore/ui_core.lua
+++ b/sdcard/color/SCRIPTS/TOOLS/GaugeCore/ui_core.lua
@@ -1,0 +1,567 @@
+---- #########################################################################
+---- # Gauge Core - shared retained LVGL and semantic UI primitives          #
+---- #########################################################################
+
+local M = {}
+local floor, max = math.floor, math.max
+local T, G, F
+
+function M.setup(theme, geometry, format)
+  T, G, F = theme, geometry, format
+end
+
+M.COLOR_STATIC, M.COLOR_THRESHOLD, M.COLOR_RAIL, M.COLOR_GRADIENT,
+  M.COLOR_SECTIONS = 1, 2, 3, 4, 5
+
+-- Property writes are QUEUED per object and flushed in one lvgl.set call at
+-- the end of the frame: each lvgl.set is a full C++ getParams + refresh(), so
+-- a state transition that touches six objects with two keys each used to
+-- emit 14 refreshes when 6 would do (AUDIT.md P2-2). The cache still filters
+-- unchanged keys, and it is updated immediately, so later reads in the same
+-- frame see the new value.
+local function setProp(widget, obj, key, value)
+  if not obj then return end
+  local frame = widget.frame
+  local props = frame.props
+  local cache = props[obj]
+  if not cache then
+    cache = {}
+    props[obj] = cache
+  end
+  if cache[key] == value then return end
+  cache[key] = value
+  -- Keep one dirty-property table per retained LVGL object. Clearing the
+  -- table after flush makes it reusable, avoiding one table allocation for
+  -- every moving segment on every frame.
+  local dirty = frame.dirty
+  if not dirty then
+    dirty = {}
+    frame.dirty = dirty
+  end
+  local t = dirty[obj]
+  if not t then
+    t = {}
+    dirty[obj] = t
+  end
+  local queued = frame.dirtyQueued
+  if not queued then
+    queued = {}
+    frame.dirtyQueued = queued
+  end
+  if not queued[obj] then
+    queued[obj] = true
+    local list = frame.dirtyList
+    if not list then
+      list = {}
+      frame.dirtyList = list
+    end
+    local n = (frame.dirtyCount or 0) + 1
+    frame.dirtyCount = n
+    list[n] = obj
+  end
+  t[key] = value
+end
+M.setProp = setProp
+
+-- Send every queued property for each object in a single lvgl.set call.
+-- Called once at the end of each update frame (renderer and bar).
+--
+-- F-01 (docs/visual-kit/INFORME-DEFECTOS.md): on the radio,
+-- LvglWidgetRoundObject::refresh() - which EVERY lvgl.set on an arc or
+-- circle triggers, whichever property changed - recomputes the object's
+-- screen position from its OWN cached x/y, and that recompute lands wrong
+-- for any arc that has already been shown once. Confirmed empirically with
+-- an isolated repro against this exact build (not a Gauge Pro bug): a
+-- freshly built arc paints correctly; the moment ANY property on it is
+-- rewritten with lvgl.set - endAngle, colour, opacity, doesn't matter which
+-- - it jumps off-centre. Reaffirming radius.coord does not help (the radio
+-- clamps back to the SAME wrong spot). The one fix that reproducibly holds,
+-- confirmed across four consecutive updates at the dial's real radius, is
+-- resending the UNCONVERTED centre as x/y in that SAME lvgl.set call, every
+-- time, forever - so every batched write to a round object carries it here,
+-- rather than patching each call site (and rather than the corner-coordinate
+-- correction floated in the original writeup, which measured no better than
+-- doing nothing).
+function M.flush(widget)
+  local frame = widget.frame
+  local count = frame.dirtyCount or 0
+  if count == 0 then return end
+  local dirty, list, queued = frame.dirty, frame.dirtyList,
+    frame.dirtyQueued
+  -- On widget.ui, NOT widget.frame: M.build() below unconditionally replaces
+  -- widget.frame wholesale (a fresh per-build animation-state table) AFTER
+  -- every arc in this file has already been built and marked, so a registry
+  -- kept on frame would be thrown away before its first flush ever runs.
+  -- widget.ui is the retained object tree and is only ever added to, never
+  -- replaced, once M.build() starts - the correct home for "which of these
+  -- retained objects need this treatment".
+  local round, L = widget.ui.roundCenters, widget.layout
+  for i = 1, count do
+    local obj = list[i]
+    local t = dirty[obj]
+    if round and round[obj] then
+      t.x, t.y = L.cx, L.cy
+    end
+    lvgl.set(obj, t)
+    for key in pairs(t) do t[key] = nil end
+    queued[obj] = nil
+  end
+  frame.dirtyCount = 0
+end
+
+-- Registers `obj` (an arc or circle whose centre is the dial's own L.cx/L.cy)
+-- so every future setProp-batched write to it re-sends that centre - see the
+-- F-01 note on M.flush above. Objects that are never updated after build
+-- (the track) do not need this: the bug only shows up on a SUBSEQUENT
+-- lvgl.set, and a freshly built arc is already correct.
+
+local function label(box, font, color, align, text)
+  return lvgl.label{
+    x = box.x, y = box.y, w = box.w, h = box.h,
+    text = text or "", font = font, color = color, align = align or LEFT,
+  }
+end
+M.label = label
+
+-- ---------------------------------------------------------------- colours --
+
+-- Semantic key for the current frame. Gradient mode quantises the ramp so a
+-- slowly drifting value does not repaint on every frame.
+function M.colorKey(widget)
+  local data, cfg = widget.data, widget.config
+  if data.availability ~= "valid" or data.displayValue == nil then
+    return "muted"
+  end
+  if widget.source.isTimer and data.value and data.value < 0 then
+    return "warning"  -- elapsed countdown, as the official Value widget does
+  end
+  if cfg.colorMode == M.COLOR_STATIC then return "static" end
+  if cfg.colorMode == M.COLOR_GRADIENT then
+    -- ramp across the THRESHOLDS, not the whole scale: red at the critical
+    -- boundary, green once the value is in the normal band (GaugeRotary's
+    -- getRangeColor semantics). A gradient over min..max would show green
+    -- while the value sits just above the warning line.
+    local lo, hi = cfg.crit, cfg.warn
+    if lo > hi then lo, hi = hi, lo end
+    -- Equal thresholds give the ramp a zero span, so normalize() pins every
+    -- value to the red end (AUDIT.md P1-5). Fall back to the band colour: a
+    -- warn == crit configuration is a sharp cliff, and the state already says
+    -- which side of it the value is on.
+    if lo == hi then return data.state or "normal" end
+    local t = G.normalize(data.displayValue, lo, hi)
+    if not cfg.highGood then t = 1 - t end
+    return "grad" .. floor(t * 20)
+  end
+  return data.state or "normal"
+end
+
+-- The colour for a semantic key: accent in Static mode, the gradient ramp
+-- for gradN, the theme role otherwise. Shared with the bar (Tanda 6 F-15:
+-- bar.lua used to carry its own copy of this).
+local function resolveColor(widget, key, palette)
+  if key == "static" then return widget.accent or T.color.accent end
+  if string.sub(key, 1, 4) == "grad" then
+    local step = tonumber(string.sub(key, 5)) or 0
+    if palette then return T.paletteColor(palette, step / 20, 20) end
+    return T.gradientColor(step / 20)
+  end
+  return T.stateColor(key, widget.accent, palette)
+end
+M.resolveColor = resolveColor
+
+-- ---- spatial gradient (shared by both families) --------------------------
+--
+-- Gradient means ONE thing: the colour of a point is the severity OF THAT
+-- POINT ON THE SCALE, so the whole instrument shows where the bad end is
+-- before the reading ever gets there. The bar slices its axis; the dial
+-- slices its arc. They differ in geometry and in nothing else - the rule,
+-- the slice budget and the colour lookup all live here so a change to one
+-- family cannot quietly become a second meaning in the other.
+--
+-- The dial used to take a completely different route: one colour for the
+-- whole arc, interpolated from the CURRENT value's distance to the
+-- thresholds. That is a legitimate idea, but it is not this one, and two
+-- gauges on one screen answered different questions under one option name.
+
+-- How many slices a run of `length` px deserves, capped by the object budget.
+function M.gradientSliceCount(length, available)
+  local target = math.ceil(math.max(1, tonumber(length) or 1) / T.px(12))
+  target = math.max(8, math.min(24, target))
+  return math.max(1, math.min(target, floor(tonumber(available) or 24)))
+end
+
+-- Map a physical position on the authored scale into the semantic gradient:
+-- critical=0, warning=.5, normal=1. Descending scales and low-is-good both
+-- fall out of the same value mapping instead of swapping face-local bands.
+function M.gradientPosition(cfg, axisPosition)
+  axisPosition = math.max(0, math.min(1, tonumber(axisPosition) or 0))
+  local value = cfg.min + (cfg.max - cfg.min) * axisPosition
+  local lo, hi = cfg.crit, cfg.warn
+  if lo > hi then lo, hi = hi, lo end
+  if lo == hi then
+    if cfg.highGood then return (value >= hi) and 1 or 0 end
+    return (value <= lo) and 1 or 0
+  end
+  local t = G.normalize(value, lo, hi)
+  if not cfg.highGood then t = 1 - t end
+  return t
+end
+
+-- The colour a slice at `position` takes. `palette` is the bar's resolved
+-- table; the dial has no palette resolver and passes nil, which falls back to
+-- the calibrated status colours - the same three the bar's "classic" palette
+-- carries, so both families land on identical RGB for identical severities.
+function M.spatialColor(cfg, palette, position)
+  palette = palette or T.color
+  local t = M.gradientPosition(cfg, position)
+  if t <= 0 then return palette.critical or T.color.crit end
+  if t >= 1 then return palette.normal or T.color.accent end
+  if t == 0.5 then return palette.warning or T.color.warn end
+  return T.paletteColor(palette.critical and palette or nil, t, 24)
+end
+
+-- The colour for the VALUE text. Shared with the bar (bar.lua calls it), so
+-- both orientations obey the same rule.
+--
+-- The status colour used to drive this directly, which is how a UI-background
+-- role ended up as the primary readout's ink. The value is DATA, so it takes
+-- the theme's own text role and stays legible whatever the state (Tanda 8
+-- §3.2). Two exceptions, both deliberate:
+--   * CRITICAL - alarm outranks neutral legibility, it is the universal
+--     convention, and the fixed red clears 3:1 on both reference backgrounds.
+--   * MUTED - a gauge with no data must RECEDE; leaving the value at full
+--     theme ink would make a stale reading look like a live one.
+-- Takes the STATE key, never the frame's colour key: in Static mode colorKey
+-- is permanently "static" and in Gradient mode "grad0".."grad20", so a value
+-- coloured from there would never have turned red in two of the five modes.
+function M.valueColor(key, palette)
+  if key == "critical" then
+    return (palette and palette.critical) or T.color.crit
+  end
+  if key == "muted" then return (palette and palette.muted) or T.color.muted end
+  return (palette and palette.value) or T.color.value
+end
+
+-- The value's ink follows the STATE, and the state moves independently of the
+-- colour key, so it needs a gate of its own. Shared with the bar.
+function M.applyStateInk(widget, palette)
+  local frame = widget.frame
+  -- through the module table: stateKey is declared further down the file
+  local skey = M.stateKey(widget)
+  local paletteSig = palette and palette.signature
+  if skey ~= frame.stateKey or paletteSig ~= frame.stateInkPaletteSig then
+    frame.stateKey = skey
+    frame.stateInkPaletteSig = paletteSig
+    local ink = M.valueColor(skey, palette)
+    setProp(widget, widget.ui.valueLabel, "color", ink)
+    -- The unit goes with it in the two EXCEPTION states, and only there.
+    -- "22" in red beside "dB" in the label role read as two different things
+    -- when they are one token; the same split made a stale "78" grey next to
+    -- a live-looking blue "dB". In the ordinary states the unit keeps its
+    -- quieter role on purpose - that hierarchy (big dark number, small quiet
+    -- unit) is what makes the number the thing you see first.
+    if widget.ui.unitLabel then
+      setProp(widget, widget.ui.unitLabel, "color",
+              (ink == ((palette and palette.value) or T.color.value))
+                and ((palette and palette.label) or T.color.label) or ink)
+    end
+  end
+end
+
+
+-- ---------------------------------------------------------------- updates --
+
+local function stateText(widget)
+  local data = widget.data
+  local a = data.availability
+  if a == "unset" then return "NO SOURCE" end
+  if a == "disconnected" then return "NO LINK" end
+  if a == "stale" then return "STALE" end
+  if a ~= "valid" then return "NO DATA" end
+  -- An elapsed countdown timer is classified WARNING by colorKey (the arc is
+  -- amber); its raw state is critical because a negative value sits below the
+  -- scale minimum. The chip must say what the instrument paints - a CRIT
+  -- word in warning colour is the worst of both worlds (AUDIT.md G-3).
+  if widget.source.isTimer and data.value and data.value < 0 then
+    return "WARN"
+  end
+  if data.state == "warning" then return "WARN" end
+  if data.state == "critical" then return "CRIT" end
+  if widget.limitNotice then return widget.limitNotice.text or "LIMIT" end
+  return ""
+end
+M.stateText = stateText
+
+-- The semantic key BEHIND the chip's text, which is not always the frame's
+-- colour key: in Static mode colorKey is permanently "static", and in Gradient
+-- mode it is "grad0".."grad20". Colouring the badge from those would have
+-- printed CRIT on an all-clear fill in two of the five colour modes.
+local function stateKey(widget)
+  local data = widget.data
+  if data.availability ~= "valid" then return "muted" end
+  if widget.source.isTimer and data.value and data.value < 0 then
+    return "warning"
+  end
+  return data.state or "normal"
+end
+M.stateKey = stateKey
+
+-- Show or hide the state chip, hugging its text. Shared by the dial and the
+-- bar so both signal state identically: the bar used to have no chip at all,
+-- leaving WARN/CRIT as bare text in bar zones while dial zones got the full
+-- pill (AUDIT.md P1-10).
+function M.updateChip(widget, s, palette)
+  local ui, frame = widget.ui, widget.frame
+  if not ui.chip then return end
+  local show = (s ~= "")
+  -- F9: `State chip = Off` is an appearance preference, and it used to
+  -- suppress the pill in EVERY state - including WARN and CRIT. That left the
+  -- normal/warning distinction resting on hue alone, which is precisely the
+  -- discrimination ~8 % of a heavily male audience cannot make; the measured
+  -- deuteranopia distance between this widget's warning and critical colours
+  -- is 25.6, well inside the ~60 confusion threshold. The option now hides the
+  -- INFORMATIONAL chips (NO LINK, STALE, NO DATA, NO SOURCE) and leaves the
+  -- two that carry a safety signal alone. In the normal state it never had
+  -- anything to hide: stateText returns "" there.
+  if show and widget.config.showChip == false then
+    local k = stateKey(widget)
+    -- LIMIT is the explicit-option refusal contract, not a routine status
+    -- decoration. Keep it observable even when quiet state chips are off;
+    -- otherwise the exact configuration that needs an explanation becomes
+    -- silent again. WARN/CRIT retain their existing safety priority.
+    local noticeText = widget.limitNotice
+      and (widget.limitNotice.text or "LIMIT")
+    show = (k == "warning" or k == "critical" or s == noticeText)
+  end
+  if show then
+    -- the chip hugs its text: measured here because the state string changes
+    -- rarely (never per frame), unlike the value
+    local L = widget.layout
+    local w = T.textWidth(s, L.stateFont) + L.chipPad * 2
+    local x = L.stateBox.x
+    if L.stateAlign == CENTER then
+      x = L.stateBox.x + floor((L.stateBox.w - w) / 2)
+    elseif L.stateAlign == RIGHT then
+      x = L.stateBox.x + L.stateBox.w - w
+    end
+    -- The pill HUGS its text, so it can come out wider than the box it was
+    -- aligned in - a narrow text column in a horizontal zone is exactly that
+    -- case - and the outline then adds chipOutline beyond it on each side.
+    -- Measured at 80x56 (LCD_SCALE 0.8): the CRIT outline ended 1 px past the
+    -- right edge of the zone. Clamp the pill, outline included, into the zone
+    -- so the widget never paints outside itself.
+    local edge = L.chipOutline
+    local maxW = max(L.w - edge * 2, 1)
+    if w > maxW then w = maxW end
+    if x + w + edge > L.w then x = L.w - w - edge end
+    if x < edge then x = edge end
+    setProp(widget, ui.chip, "x", x)
+    setProp(widget, ui.chip, "w", w)
+    if ui.chipEdge then
+      setProp(widget, ui.chipEdge, "x", x - L.chipOutline)
+      setProp(widget, ui.chipEdge, "w", w + L.chipOutline * 2)
+    end
+    -- Centre the text INSIDE the pill it now hugs. The label was placed
+    -- against stateBox, and for a RIGHT-aligned state row - the bar's - the
+    -- pill's right edge coincides with stateBox's, so the word came out
+    -- flush against the pill's right side with the whole 2 * chipPad sitting
+    -- on the left. Re-anchoring the label to the PILL makes the padding
+    -- symmetric for every alignment; for the dial's CENTER row both are
+    -- already concentric, so this changes nothing there.
+    if ui.stateLabel then
+      setProp(widget, ui.stateLabel, "x", x)
+      setProp(widget, ui.stateLabel, "w", w)
+      setProp(widget, ui.stateLabel, "align", CENTER)
+    end
+    -- F8: the pill is a BADGE - the status colour is its GROUND, not its ink.
+    --
+    -- It used to be a COLOR_THEME_SECONDARY2 fill (a "label/button background"
+    -- role) carrying the status colour as text. On the stock theme that is a
+    -- #b6e0f2 fill at 1.19:1 against the screen - an invisible pill, read only
+    -- through its 1 px outline - with CRIT printed on it at 2.91:1, under the
+    -- 3:1 floor. So the most glanceable element in the widget, the one that
+    -- says CRIT, was its weakest: a hairline outline around thin coloured text,
+    -- seen for ~200 ms in sunlight with the pilot's eyes on the model.
+    --
+    -- Inverted, the badge is self-grounding and measures 5.2:1 (critical),
+    -- 5.6:1 (warning), 5.4:1 (normal) and 6.4:1 (muted), on any theme, because
+    -- both the fill and the ink are ours (theme.labelOn).
+    local fill = T.stateColor(stateKey(widget), widget.accent, palette)
+    local ink = T.labelOn(fill, palette)
+    setProp(widget, ui.chip, "color", fill)
+    if ui.stateLabel then
+      setProp(widget, ui.stateLabel, "color", ink)
+    end
+    -- The outline takes the badge's OWN ink, not the label role. Under a
+    -- SECONDARY2 fill an outline in the label role was the only thing making
+    -- the pill visible, so a contrasting chrome colour made sense; over a
+    -- coloured fill it reads as a third colour stapled on - a blue hairline
+    -- around an amber badge. Ink-coloured, the badge is two colours that
+    -- belong together, and the outline still does its remaining job: holding
+    -- the shape apart from a theme background at a similar luminance, or from
+    -- a background.png photograph.
+    if ui.chipEdge then setProp(widget, ui.chipEdge, "color", ink) end
+    lvgl.show(ui.chipEdge)
+    lvgl.show(ui.chip)
+    -- The LABEL travels with the pill. Before F9 this was implicit: the chip
+    -- objects only existed when the option was on, so hiding "the chip" hid
+    -- everything. Now the objects always exist and only their visibility
+    -- moves - and a hidden pill with a visible label left "NO LINK" floating
+    -- bare on the dial, which is the very defect the pill was added to fix
+    -- (AUDIT.md P1-10, the bar's chipless WARN/CRIT text).
+    if ui.stateLabel then lvgl.show(ui.stateLabel) end
+    -- frame.chipBox used to be maintained here: the pill's footprint, read by
+    -- needleReach() to stop the needle short of it. Both are gone with Tanda 7
+    -- A - the pill is opaque and painted after the needle, so it occludes the
+    -- blade without anyone having to measure it (see updateArc).
+  else
+    lvgl.hide(ui.chipEdge)
+    lvgl.hide(ui.chip)
+    if ui.stateLabel then lvgl.hide(ui.stateLabel) end
+  end
+  frame.chipShown = show
+end
+
+-- The value is CENTRED in a box reserved at the widest sample's width
+-- (layout.placeValue, P1-1), so its own ink is always centred on the box
+-- regardless of how many digits it actually has - but the unit was placed
+-- once, at layout time, against the box's right edge. Re-anchor it to the
+-- ink's REAL right edge whenever the text changes: shared by the dial and
+-- the bar (bar.lua calls this too) so both keep the visible "value + unit"
+-- group centred at any digit count, not just at the widest sample.
+-- The live value string is measured through theme.measureWidth - EXACT but
+-- deliberately NOT memoized. Measuring it through textWidth would add one
+-- permanent entry to the shared width cache per frame at high precision
+-- (Tanda 6 F-4).
+function M.anchorUnit(widget, str)
+  local ui, L = widget.ui, widget.layout
+  if not ui.unitLabel then return end
+  local actualW = T.measureWidth(str, L.valueFont)
+  local inkRight
+  if L.valueAlign == LEFT then
+    inkRight = L.valueBox.x + actualW
+  elseif L.valueAlign == RIGHT then
+    inkRight = L.valueBox.x + L.valueBox.w
+  else
+    inkRight = L.valueBox.x + floor((L.valueBox.w + actualW) / 2)
+  end
+  -- placeValue resolves the gap once for the active family. Horizontal Dial
+  -- uses `sm`; BarPro and every legacy/default path store `md`. The fallback
+  -- keeps old serialized/test layouts safe if one reaches this renderer.
+  local x = inkRight + (L.unitGap or T.px(T.space.md))
+  -- Never anchor the unit outside the zone. In a region too small for the
+  -- value+unit group, pickValueFont's last-resort branch clamps the RESERVED
+  -- value width below the ink's real width, so ink centred in that box
+  -- overhangs to the right and drags the unit with it (measured at 24x24:
+  -- the unit label ended 2 px outside the widget). The clamp only ever bites
+  -- in that degenerate case - at any size where the group actually fits,
+  -- actualW <= valueBox.w and this x is already inside.
+  local limit = L.w - L.unitBox.w
+  if x > limit then x = limit end
+  if x < 0 then x = 0 end
+  setProp(widget, ui.unitLabel, "x", x)
+end
+
+
+-- Critical state pulses at ~1 Hz: attention without colour, so it survives
+-- greyscale and colour-blind viewing. Two property writes per second.
+-- Shared with the bar (Tanda 6 F-15): `obj` is the pulse target - the value
+-- arc for the dial, the fill for the bar.
+local function pulseOpacity(widget, obj, value)
+  if obj and obj[1] then
+    for i = 1, #obj do setProp(widget, obj[i], "opacity", value) end
+  else
+    setProp(widget, obj, "opacity", value)
+  end
+end
+
+function M.updatePulse(widget, key, obj, mode, baseOpacity, resetPhase)
+  local frame = widget.frame
+  if key ~= "critical" then
+    if frame.pulseActive or frame.pulse then
+      -- Restore the opacity the NEW key calls for, not always full: losing
+      -- the link while the pulse is in its trough must leave the gauge dim.
+      baseOpacity = baseOpacity
+        or ((key == "muted") and T.opacity.muted or T.opacity.full)
+      pulseOpacity(widget, obj, baseOpacity)
+      frame.pulse = false
+      frame.pulseActive = false
+      frame.pulsePhase = nil
+    end
+    return
+  end
+  mode = mode or "essential" -- nil preserves the approved dial behavior
+  baseOpacity = baseOpacity or T.opacity.full
+  if mode == "off" then
+    if frame.pulseActive or frame.pulse then
+      pulseOpacity(widget, obj, baseOpacity)
+      frame.pulse = false
+      frame.pulseActive = false
+      frame.pulsePhase = nil
+    end
+    frame.pulseMode = mode
+    return
+  end
+  local now = getTime()
+  if resetPhase or not frame.pulseActive or frame.pulseMode ~= mode then
+    frame.pulseAt = now
+    frame.pulse = false
+    frame.pulseActive = true
+    frame.pulsePhase = 0
+    frame.pulseMode = mode
+    pulseOpacity(widget, obj, baseOpacity)
+    return
+  end
+
+  if mode == "essential" then
+    if now - frame.pulseAt >= 50 then  -- two writes -> one calm 1 Hz cycle
+      frame.pulseAt = now
+      frame.pulse = not frame.pulse
+      pulseOpacity(widget, obj,
+                   frame.pulse and T.opacity.pulse or baseOpacity)
+    end
+    return
+  end
+
+  -- Refined/Expressive: the same one-second period, quantized into a calm
+  -- full -> mid -> trough -> mid breath. Four writes per second is bounded,
+  -- avoids high-frequency shimmer, and is still allocation-free.
+  local elapsed = now - frame.pulseAt
+  if elapsed >= 100 then
+    frame.pulseAt = now - (elapsed % 100)
+    elapsed = elapsed % 100
+  end
+  local phase = floor(elapsed / 25)
+  if phase ~= frame.pulsePhase then
+    frame.pulsePhase = phase
+    frame.pulse = phase ~= 0
+    local opacity = baseOpacity
+    if phase == 2 then
+      opacity = T.opacity.pulse
+    elseif phase == 1 or phase == 3 then
+      opacity = floor((baseOpacity + T.opacity.pulse) / 2 + 0.5)
+    end
+    pulseOpacity(widget, obj, opacity)
+  end
+end
+
+function M.updateSourceLabels(widget)
+  local ui = widget.ui
+  if ui.unitLabel then
+    setProp(widget, ui.unitLabel, "text", widget.unitText or "")
+  end
+  if ui.nameLabel then
+    setProp(widget, ui.nameLabel, "text", widget.nameText or "")
+  end
+  if ui.scaleMin then
+    setProp(widget, ui.scaleMin, "text", F.display(widget, widget.config.min))
+    setProp(widget, ui.scaleMax, "text", F.display(widget, widget.config.max))
+  end
+  -- This runs from app.update(), OUTSIDE the frame's refresh: flush the
+  -- queued writes here so a Name/Suffix edit reaches LVGL before the next
+  -- refresh (the cheap delta path of AUDIT.md P0-6).
+  M.flush(widget)
+end
+
+
+return M

--- a/sdcard/color/WIDGETS/GaugeBarPro/README.md
+++ b/sdcard/color/WIDGETS/GaugeBarPro/README.md
@@ -1,0 +1,44 @@
+# Gauge Bar Pro
+
+Gauge Bar Pro (`BarPro` in the widget picker) is the linear member of the
+Gauge Pro telemetry family for EdgeTX color radios.
+
+This is the first public beta. Feedback about radio compatibility, missing
+features, configuration options, layout behavior and visual improvements is
+welcome.
+
+## Features
+
+- Responsive horizontal and vertical layouts from small zones to full screen.
+- Continuous, gradient, blocks, hex, ticks, signal-steps and dual-rail faces.
+- Configurable origin, direction, thickness, ends, scale marks, value and label
+  placement, palettes and contrast assistance.
+- Ascending or descending ranges, warning and critical thresholds, history
+  markers and optional motion smoothing.
+- Numeric telemetry, timers, sticks, channels, GVars, transmitter battery and
+  battery-cell interpretation.
+
+EdgeTX 2.11 exposes the stable ten-option compatibility set. EdgeTX 2.12 and
+later expose the complete 42-option set.
+
+## Installation
+
+The official color SD-card packages install both required parts:
+
+```text
+/WIDGETS/GaugeBarPro/main.lua
+/SCRIPTS/TOOLS/GaugeCore/*.lua
+```
+
+For a manual installation, copy both directories from `sdcard/color/`. The
+widget cannot run if only its `main.lua` frontend is copied.
+
+## Beta feedback and safety
+
+When reporting a problem, include the radio model, exact EdgeTX version,
+telemetry source, widget-zone size, theme, non-default options and a screenshot
+or simulator log when possible.
+
+Back up the SD card and model configuration before testing. Do not use this
+beta widget as the only warning for a flight-critical condition; retain the
+radio's normal alarms and telemetry failsafes.

--- a/sdcard/color/WIDGETS/GaugeBarPro/main.lua
+++ b/sdcard/color/WIDGETS/GaugeBarPro/main.lua
@@ -1,0 +1,213 @@
+---- #########################################################################
+---- # Gauge Bar - bar frontend backed by the shared GaugeCore               #
+---- #########################################################################
+
+local TEST = ...
+local NAME = "BarPro"
+local CORE_API = 1
+local CORE_PATH = "/SCRIPTS/TOOLS/GaugeCore/"
+if type(TEST) == "table" and type(TEST.corePath) == "string" then
+  CORE_PATH = TEST.corePath
+end
+if string.sub(CORE_PATH, -1) ~= "/" then CORE_PATH = CORE_PATH .. "/" end
+
+if lvgl == nil then
+  return {
+    name = NAME,
+    options = {},
+    create = function(zone) return { zone = zone } end,
+    update = function() end,
+    refresh = function()
+      lcd.drawText(3, 3, "Gauge Bar needs EdgeTX 2.11+", SMLSIZE)
+    end,
+  }
+end
+
+-- Wire contract: existing entries are immutable and new entries append only.
+-- The shared prefix is pinned against GaugeDialPro by widgets_test.lua.
+local DEFS = {
+  { key = "Source", label = "Source", type = SOURCE, field = "source",
+    since = 211, default = { "RSSI", "RQly", "RxBt", "Cels", "TxBt" } },
+  { key = "Min", label = "Scale low", type = VALUE, field = "min",
+    since = 211, default = 0, min = -10000, max = 10000 },
+  { key = "Max", label = "Scale high", type = VALUE, field = "max",
+    since = 211, default = 100, min = -10000, max = 10000 },
+  { key = "Warn", label = "Warn level", type = VALUE, field = "warn",
+    since = 211, default = 55, min = -10000, max = 10000 },
+  { key = "Crit", label = "Critical level", type = VALUE, field = "crit",
+    since = 211, default = 35, min = -10000, max = 10000 },
+  { key = "HighGood", label = "High = good", type = BOOL,
+    field = "highGood", since = 211, default = 1 },
+  { key = "ColorMode", label = "Colour mode", type = CHOICE,
+    field = "colorMode", since = 211, default = 3,
+    choices = { "Static", "Threshold", "Rail", "Gradient", "Sections" } },
+  { key = "Precision", label = "Decimals", type = CHOICE,
+    field = "precision", since = 211, default = 1,
+    choices = { "Auto", "0", "1", "2" } },
+  { key = "ShowMinMax", label = "Min/max marks", type = CHOICE,
+    field = "showMinMax", since = 211, default = 2,
+    choices = { "Off", "Markers", "Markers + text" } },
+
+  -- Family selector, intentionally in the 2.11-visible tenth slot.
+  { key = "BarPreset", label = "Bar preset", type = CHOICE,
+    field = "barPreset", since = 211, default = 2,
+    choices = { "Auto", "Classic", "Theme", "Hex", "Blocks", "Ticks",
+                "RC center", "Minimal", "Bold data" } },
+
+  { key = "Accent", label = "Normal colour", type = COLOR, field = "accent",
+    since = 212, default = lcd.RGB(0x20, 0x90, 0x58) },
+  { key = "Label", label = "Name override", type = STRING, field = "label",
+    since = 212, default = "" },
+  { key = "Suffix", label = "Unit override", type = STRING, field = "suffix",
+    since = 212, default = "" },
+  { key = "Scale", label = "Scale ends", type = CHOICE, field = "scale",
+    since = 212, default = 1, choices = { "Auto", "Manual" } },
+  { key = "Damping", label = "Gauge damping", type = SLIDER,
+    field = "damping", since = 212, default = 4, min = 0, max = 9 },
+  { key = "Cells", label = "Cell reading", type = CHOICE, field = "cells",
+    since = 212, default = 1, choices = { "Lowest", "Total", "Average" } },
+  { key = "Battery", label = "Volts as %", type = CHOICE,
+    field = "battery", since = 212, default = 1,
+    choices = { "Off", "Li-Po", "Li-Ion" } },
+  { key = "Alerts", label = "Alerts", type = CHOICE, field = "alerts",
+    since = 212, default = 1,
+    choices = { "Off", "Critical", "Warning + critical" } },
+  { key = "AlertSw", label = "  Alert switch", type = SWITCH,
+    field = "alertSw", since = 212, default = 0 },
+  { key = "Delay", label = "  Startup delay (s)", type = VALUE,
+    field = "delay", since = 212, default = 4, min = 0, max = 30 },
+  { key = "Vibrate", label = "  Vibrate", type = BOOL,
+    field = "vibrate", since = 212, default = 0 },
+  { key = "ResetSw", label = "Reset min/max", type = SWITCH,
+    field = "resetSw", since = 212, default = 0 },
+  { key = "ShowChip", label = "Info badges", type = BOOL,
+    field = "showChip", since = 212, default = 1 },
+
+  { key = "BarFace", label = "Bar face", type = CHOICE,
+    field = "barFace", since = 212, default = 1,
+    choices = { "Auto", "Continuous", "Blocks", "Hex", "Ticks", "Steps",
+                "Dual rail" } },
+  { key = "BarDir", label = "Bar direction", type = CHOICE,
+    field = "barDir", since = 212, default = 1,
+    choices = { "Auto", "Horizontal", "Vertical" } },
+  { key = "BarOrigin", label = "Bar origin", type = CHOICE,
+    field = "barOrigin", since = 212, default = 1,
+    choices = { "Auto", "Scale low", "Zero" } },
+  { key = "BarSize", label = "Bar thickness", type = CHOICE,
+    field = "barSize", since = 212, default = 1,
+    choices = { "Auto", "Thin", "Medium", "Thick", "Maximum" } },
+  { key = "BarEnds", label = "Bar ends", type = CHOICE,
+    field = "barEnds", since = 212, default = 1,
+    choices = { "Auto", "Round", "Square", "Chamfer" } },
+  { key = "Segments", label = "Bar segments", type = CHOICE,
+    field = "segments", since = 212, default = 1,
+    choices = { "Auto", "6", "8", "10", "12", "16", "24" } },
+  { key = "SegGap", label = "Segment gap", type = CHOICE,
+    field = "segGap", since = 212, default = 1,
+    choices = { "Auto", "Tight", "Normal", "Wide" } },
+  { key = "Palette", label = "Palette", type = CHOICE,
+    field = "palette", since = 212, default = 1,
+    choices = { "Auto", "Classic", "Theme adaptive", "Custom 3",
+                "Custom 2" } },
+  { key = "WarnClr", label = "Warning colour", type = COLOR,
+    field = "warnClr", since = 212, default = lcd.RGB(0xc8, 0x60, 0x00) },
+  { key = "CritClr", label = "Critical colour", type = COLOR,
+    field = "critClr", since = 212, default = lcd.RGB(0xff, 0x00, 0x00) },
+  { key = "TrackClr", label = "Track colour", type = COLOR,
+    field = "trackClr", since = 212, default = COLOR_THEME_SECONDARY1 },
+  { key = "Surface", label = "Surface", type = CHOICE,
+    field = "surface", since = 212, default = 1,
+    choices = { "Auto", "Transparent", "Theme panel", "Custom colors" } },
+  { key = "PanelClr", label = "Panel colour", type = COLOR,
+    field = "panelClr", since = 212, default = COLOR_THEME_SECONDARY3 },
+  { key = "Contrast", label = "Contrast assist", type = CHOICE,
+    field = "contrast", since = 212, default = 1,
+    choices = { "Auto", "Off", "Strong" } },
+  { key = "Motion", label = "Motion", type = CHOICE,
+    field = "motion", since = 212, default = 1,
+    choices = { "Auto", "Off", "Essential", "Refined", "Expressive" } },
+  { key = "BarHead", label = "Position head", type = CHOICE,
+    field = "barHead", since = 212, default = 1,
+    choices = { "Auto", "None", "Cap", "Dot", "Line", "Needle" } },
+  { key = "ScaleMarks", label = "Scale marks", type = CHOICE,
+    field = "scaleMarks", since = 212, default = 1,
+    choices = { "Auto", "Off", "Thresholds", "Ends", "Full" } },
+  { key = "ValuePos", label = "Value position", type = CHOICE,
+    field = "valuePos", since = 212, default = 1,
+    choices = { "Auto", "Above", "Inside", "End", "Off" } },
+  { key = "LabelPos", label = "Name position", type = CHOICE,
+    field = "labelPos", since = 212, default = 1,
+    choices = { "Auto", "Above", "Below", "Inside", "Off" } },
+}
+
+local SPEC = { name = NAME, family = "bar", coreApi = CORE_API, defs = DEFS }
+
+local CORE, EXTENDED = 10, 50
+local capacity = CORE
+if type(getVersion) == "function" then
+  local _, _, major, minor = getVersion()
+  major, minor = tonumber(major), tonumber(minor)
+  if major and (major > 2 or (major == 2 and (minor or 0) >= 12)) then
+    capacity = EXTENDED
+  end
+end
+
+local options = {}
+local labels = { [NAME] = "Gauge Bar Pro" }
+for i = 1, #DEFS do
+  local d = DEFS[i]
+  labels[d.key] = d.label
+  local needs = (d.since == 212) and EXTENDED or CORE
+  if needs <= capacity and #options < capacity then
+    if d.type == CHOICE then
+      options[#options + 1] = { d.key, d.type, d.default, d.choices }
+    elseif d.type == VALUE or d.type == SLIDER then
+      options[#options + 1] = { d.key, d.type, d.default, d.min, d.max }
+    else
+      options[#options + 1] = { d.key, d.type, d.default }
+    end
+  end
+end
+
+local function translate(name) return labels[name] end
+local sharedApp
+
+local function create(zone, opts, _widgetPath)
+  if not sharedApp then
+    local chunk, err = loadScript(CORE_PATH .. "app.lua", "bt")
+    if not chunk then
+      error(NAME .. ": cannot load GaugeCore/app.lua from " .. CORE_PATH
+        .. " (" .. tostring(err) .. ")")
+    end
+    sharedApp = chunk(SPEC)
+    if type(sharedApp) ~= "table" or sharedApp.coreApi ~= CORE_API then
+      error(NAME .. ": incompatible GaugeCore API (expected "
+        .. tostring(CORE_API) .. ")")
+    end
+  end
+  local widget = sharedApp.create(zone, opts, CORE_PATH)
+  widget.app = sharedApp
+  return widget
+end
+
+local function update(widget, opts)
+  if widget.app then widget.app.update(widget, opts) end
+end
+
+local function refresh(widget, event, touch)
+  if widget.app then widget.app.refresh(widget, event, touch) end
+end
+
+return {
+  name = NAME,
+  options = options,
+  translate = translate,
+  create = create,
+  update = update,
+  refresh = refresh,
+  useLvgl = true,
+  defs = DEFS,
+  family = SPEC.family,
+  coreApi = CORE_API,
+  corePath = CORE_PATH,
+}

--- a/sdcard/color/WIDGETS/GaugeDialPro/README.md
+++ b/sdcard/color/WIDGETS/GaugeDialPro/README.md
@@ -1,0 +1,43 @@
+# Gauge Dial Pro
+
+Gauge Dial Pro (`DialPro` in the widget picker) is the radial member of the
+Gauge Pro telemetry family for EdgeTX color radios.
+
+This is the first public beta. Feedback about radio compatibility, missing
+features, configuration options, layout behavior and visual improvements is
+welcome.
+
+## Features
+
+- Responsive dial layouts from small zones to full screen.
+- Needle and arc styles with 180, 270 and 360 degree sweeps.
+- Ascending or descending ranges, warning and critical thresholds, history
+  markers and optional motion smoothing.
+- Theme-aware colors and unavailable-data states.
+- Numeric telemetry, timers, sticks, channels, GVars, transmitter battery and
+  battery-cell interpretation.
+
+EdgeTX 2.11 exposes the stable ten-option compatibility set. EdgeTX 2.12 and
+later expose the complete 24-option set.
+
+## Installation
+
+The official color SD-card packages install both required parts:
+
+```text
+/WIDGETS/GaugeDialPro/main.lua
+/SCRIPTS/TOOLS/GaugeCore/*.lua
+```
+
+For a manual installation, copy both directories from `sdcard/color/`. The
+widget cannot run if only its `main.lua` frontend is copied.
+
+## Beta feedback and safety
+
+When reporting a problem, include the radio model, exact EdgeTX version,
+telemetry source, widget-zone size, theme, non-default options and a screenshot
+or simulator log when possible.
+
+Back up the SD card and model configuration before testing. Do not use this
+beta widget as the only warning for a flight-critical condition; retain the
+radio's normal alarms and telemetry failsafes.

--- a/sdcard/color/WIDGETS/GaugeDialPro/main.lua
+++ b/sdcard/color/WIDGETS/GaugeDialPro/main.lua
@@ -1,0 +1,160 @@
+---- #########################################################################
+---- # Gauge Dial - dial frontend backed by the shared GaugeCore             #
+---- #########################################################################
+
+local TEST = ...
+local NAME = "DialPro"
+local CORE_API = 1
+local CORE_PATH = "/SCRIPTS/TOOLS/GaugeCore/"
+if type(TEST) == "table" and type(TEST.corePath) == "string" then
+  CORE_PATH = TEST.corePath
+end
+if string.sub(CORE_PATH, -1) ~= "/" then CORE_PATH = CORE_PATH .. "/" end
+
+-- Keep the widget registered on unsupported firmware so the model retains
+-- its configuration and the pilot gets an actionable message.
+if lvgl == nil then
+  return {
+    name = NAME,
+    options = {},
+    create = function(zone) return { zone = zone } end,
+    update = function() end,
+    refresh = function()
+      lcd.drawText(3, 3, "Gauge Dial needs EdgeTX 2.11+", SMLSIZE)
+    end,
+  }
+end
+
+-- Wire contract: existing entries are immutable and new entries append only.
+-- The shared prefix is pinned against GaugeBarPro by widgets_test.lua.
+local DEFS = {
+  { key = "Source", label = "Source", type = SOURCE, field = "source",
+    since = 211, default = { "RSSI", "RQly", "RxBt", "Cels", "TxBt" } },
+  { key = "Min", label = "Scale low", type = VALUE, field = "min",
+    since = 211, default = 0, min = -10000, max = 10000 },
+  { key = "Max", label = "Scale high", type = VALUE, field = "max",
+    since = 211, default = 100, min = -10000, max = 10000 },
+  { key = "Warn", label = "Warn level", type = VALUE, field = "warn",
+    since = 211, default = 55, min = -10000, max = 10000 },
+  { key = "Crit", label = "Critical level", type = VALUE, field = "crit",
+    since = 211, default = 35, min = -10000, max = 10000 },
+  { key = "HighGood", label = "High = good", type = BOOL,
+    field = "highGood", since = 211, default = 1 },
+  { key = "ColorMode", label = "Colour mode", type = CHOICE,
+    field = "colorMode", since = 211, default = 3,
+    choices = { "Static", "Threshold", "Rail", "Gradient", "Sections" } },
+  { key = "Precision", label = "Decimals", type = CHOICE,
+    field = "precision", since = 211, default = 1,
+    choices = { "Auto", "0", "1", "2" } },
+  { key = "ShowMinMax", label = "Min/max marks", type = CHOICE,
+    field = "showMinMax", since = 211, default = 2,
+    choices = { "Off", "Markers", "Markers + text" } },
+
+  -- Family selector, intentionally in the 2.11-visible tenth slot.
+  { key = "DialStyle", label = "Dial style", type = CHOICE,
+    field = "style", since = 211, default = 1,
+    choices = { "Auto", "Needle", "Arc" } },
+
+  { key = "Sweep", label = "Dial sweep", type = CHOICE, field = "sweep",
+    since = 212, default = 1, choices = { "270 deg", "180 deg", "360 deg" } },
+  { key = "Accent", label = "Normal colour", type = COLOR, field = "accent",
+    since = 212, default = lcd.RGB(0x20, 0x90, 0x58) },
+  { key = "Label", label = "Name override", type = STRING, field = "label",
+    since = 212, default = "" },
+  { key = "Suffix", label = "Unit override", type = STRING, field = "suffix",
+    since = 212, default = "" },
+  { key = "Scale", label = "Scale ends", type = CHOICE, field = "scale",
+    since = 212, default = 1, choices = { "Auto", "Manual" } },
+  { key = "Damping", label = "Gauge damping", type = SLIDER,
+    field = "damping", since = 212, default = 4, min = 0, max = 9 },
+  { key = "Cells", label = "Cell reading", type = CHOICE, field = "cells",
+    since = 212, default = 1, choices = { "Lowest", "Total", "Average" } },
+  { key = "Battery", label = "Volts as %", type = CHOICE,
+    field = "battery", since = 212, default = 1,
+    choices = { "Off", "Li-Po", "Li-Ion" } },
+  { key = "Alerts", label = "Alerts", type = CHOICE, field = "alerts",
+    since = 212, default = 1,
+    choices = { "Off", "Critical", "Warning + critical" } },
+  { key = "AlertSw", label = "  Alert switch", type = SWITCH,
+    field = "alertSw", since = 212, default = 0 },
+  { key = "Delay", label = "  Startup delay (s)", type = VALUE,
+    field = "delay", since = 212, default = 4, min = 0, max = 30 },
+  { key = "Vibrate", label = "  Vibrate", type = BOOL,
+    field = "vibrate", since = 212, default = 0 },
+  { key = "ResetSw", label = "Reset min/max", type = SWITCH,
+    field = "resetSw", since = 212, default = 0 },
+  { key = "ShowChip", label = "Info badges", type = BOOL,
+    field = "showChip", since = 212, default = 1 },
+}
+
+local SPEC = { name = NAME, family = "dial", coreApi = CORE_API, defs = DEFS }
+
+local CORE, EXTENDED = 10, 50
+local capacity = CORE
+if type(getVersion) == "function" then
+  local _, _, major, minor = getVersion()
+  major, minor = tonumber(major), tonumber(minor)
+  if major and (major > 2 or (major == 2 and (minor or 0) >= 12)) then
+    capacity = EXTENDED
+  end
+end
+
+local options = {}
+local labels = { [NAME] = "Gauge Dial Pro" }
+for i = 1, #DEFS do
+  local d = DEFS[i]
+  labels[d.key] = d.label
+  local needs = (d.since == 212) and EXTENDED or CORE
+  if needs <= capacity and #options < capacity then
+    if d.type == CHOICE then
+      options[#options + 1] = { d.key, d.type, d.default, d.choices }
+    elseif d.type == VALUE or d.type == SLIDER then
+      options[#options + 1] = { d.key, d.type, d.default, d.min, d.max }
+    else
+      options[#options + 1] = { d.key, d.type, d.default }
+    end
+  end
+end
+
+local function translate(name) return labels[name] end
+local sharedApp
+
+local function create(zone, opts, _widgetPath)
+  if not sharedApp then
+    local chunk, err = loadScript(CORE_PATH .. "app.lua", "bt")
+    if not chunk then
+      error(NAME .. ": cannot load GaugeCore/app.lua from " .. CORE_PATH
+        .. " (" .. tostring(err) .. ")")
+    end
+    sharedApp = chunk(SPEC)
+    if type(sharedApp) ~= "table" or sharedApp.coreApi ~= CORE_API then
+      error(NAME .. ": incompatible GaugeCore API (expected "
+        .. tostring(CORE_API) .. ")")
+    end
+  end
+  local widget = sharedApp.create(zone, opts, CORE_PATH)
+  widget.app = sharedApp
+  return widget
+end
+
+local function update(widget, opts)
+  if widget.app then widget.app.update(widget, opts) end
+end
+
+local function refresh(widget, event, touch)
+  if widget.app then widget.app.refresh(widget, event, touch) end
+end
+
+return {
+  name = NAME,
+  options = options,
+  translate = translate,
+  create = create,
+  update = update,
+  refresh = refresh,
+  useLvgl = true,
+  defs = DEFS,
+  family = SPEC.family,
+  coreApi = CORE_API,
+  corePath = CORE_PATH,
+}


### PR DESCRIPTION
## Summary

This draft adds the first public beta of two telemetry widgets for EdgeTX color radios:

- **Gauge Dial Pro** (`DialPro`) for responsive radial gauges
- **Gauge Bar Pro** (`BarPro`) for responsive horizontal and vertical gauges

Both frontends share a lazily loaded `GaugeCore` runtime so common telemetry, range, theme, alert, layout and rendering behavior is implemented once. The legacy combined `GaugePro` widget and all development-only visual tooling are intentionally excluded.

## SD-card layout

The contribution uses the canonical `sdcard/color/` overlay, so the official generator includes it in every color-radio package:

```text
/WIDGETS/GaugeDialPro/main.lua
/WIDGETS/GaugeBarPro/main.lua
/SCRIPTS/TOOLS/GaugeCore/*.lua
```

The two widget READMEs explain manual installation, compatibility, beta safety and how to submit useful feedback.

## Beta goals and requested feedback

This first public version is intended to collect real-radio feedback before stabilization. In particular, feedback is welcome on:

- radio and screen-size compatibility
- useful presets and missing telemetry workflows
- option discoverability and defaults
- compact-zone readability
- additional faces, motion choices and accessibility improvements

Please include the radio model, exact EdgeTX version, source, zone, theme, non-default options and a screenshot or simulator log.

## Validation

- 72/72 pure-module tests
- 220/220 lifecycle and retained-LVGL tests
- 17/17 split-frontend contract tests
- 309/309 total automated Lua tests
- `luacheck`: 21 packaged Lua files, 0 warnings/errors
- collision, object-ceiling, callback-budget, allocation, motion and boot-cost gates passed
- worst measured callback: 9,400 / 20,000 instructions
- all five color variants verified to inherit the canonical payload without an override conflict
- representative mixed-layout, severity-state and complete Bar Pro settings-form captures visually reviewed

## Known beta limitations

- No physical color-radio smoke test has been completed yet; this is the main reason the PR is a draft.
- The EdgeTX 2.11 ten-option compatibility contract is automated-test covered but still needs real-radio confirmation.
- The latest full visual catalog reports 268 pass / 9 warnings; two unexpected duplicate groups appear to be simulator-navigation capture artifacts and are still being investigated.
- Local validation covered generator syntax and overlay behavior; the repository CI should perform the full release-ZIP generation.

The widgets must not be the only warning mechanism for flight-critical conditions; normal radio alarms and telemetry failsafes should remain enabled.