### PR TITLE
fix(FlightHistory): correct seconds to minutes conversion

### DIFF
--- a/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/app.lua
+++ b/sdcard/c480x272/SCRIPTS/TOOLS/FlightsHistory/app.lua
@@ -192,7 +192,7 @@ local function state_SHOW_FLIGHTS_HIST_INIT(event, touchState)
             day,
             f_info.model_name,
             string.format("%s", f_info.flight_count),
-            string.format("%d:%02d", math.floor(f_info.duration//100), math.floor((f_info.duration/100 % 1) * 60)),
+            string.format("%d:%02d", f_info.duration//60, f_info.duration%60)
         }
     end
 

--- a/sdcard/c480x320/SCRIPTS/TOOLS/FlightsHistory/app.lua
+++ b/sdcard/c480x320/SCRIPTS/TOOLS/FlightsHistory/app.lua
@@ -192,7 +192,7 @@ local function state_SHOW_FLIGHTS_HIST_INIT(event, touchState)
             day,
             f_info.model_name,
             string.format("%s", f_info.flight_count),
-            string.format("%d:%02d", math.floor(f_info.duration//100), math.floor((f_info.duration/100 % 1) * 60)),
+            string.format("%d:%02d", f_info.duration//60, f_info.duration%60)
         }
     end
 

--- a/sdcard/c800x480/SCRIPTS/TOOLS/FlightsHistory/app.lua
+++ b/sdcard/c800x480/SCRIPTS/TOOLS/FlightsHistory/app.lua
@@ -192,7 +192,7 @@ local function state_SHOW_FLIGHTS_HIST_INIT(event, touchState)
             day,
             f_info.model_name,
             string.format("%s", f_info.flight_count),
-            string.format("%d:%02d", math.floor(f_info.duration//100), math.floor((f_info.duration/100 % 1) * 60)),
+            string.format("%d:%02d", f_info.duration//60, f_info.duration%60)
         }
     end
 


### PR DESCRIPTION
Old code displayed wrong duration in flight history viewer.
This fixes the duration displayed.

E.G. duration of 605 was being displayed as 6:03. It is now being properly displayed as 10:05