### PR TITLE
ci: auto-detect and PR sdcard.json drift against edgetx/edgetx fw.json

### DIFF
--- a/.github/workflows/sync_fw_json.yml
+++ b/.github/workflows/sync_fw_json.yml
@@ -21,7 +21,24 @@ jobs:
         run: uv run sync_fw_json.py | tee "$RUNNER_TEMP/sync-summary.md"
 
       - name: Validate updated sdcard.json
+        id: validate
+        # Non-blocking: a new target can land on a screen resolution with
+        # no sdcard/<resolution>/ directory yet (no template content),
+        # which this legitimately fails on. Still open the PR in that
+        # case so a human sees it - the "Validate sdcard.json" check on
+        # the PR itself (validate_sdcard_json.yml) will show the same
+        # failure there, which is what should block merging it.
+        continue-on-error: true
         run: uv run validate_sdcard_json.py
+
+      - name: Note validation failure in PR body
+        if: steps.validate.outcome == 'failure'
+        run: |
+          {
+            echo ""
+            echo "---"
+            echo "⚠️ **\`validate_sdcard_json.py\` failed on the updated file** - likely a new target landed on a screen resolution with no matching \`sdcard/<resolution>/\` directory yet. Check the \"Validate sdcard.json\" status check on this PR before merging; it needs template content added under \`sdcard/\` first."
+          } >> "$RUNNER_TEMP/sync-summary.md"
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/sync_fw_json.yml
+++ b/.github/workflows/sync_fw_json.yml
@@ -1,0 +1,34 @@
+name: Sync sdcard.json with fw.json
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # Weekly on Monday at 3 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Check EdgeTX/edgetx fw.json for drift
+        id: sync
+        run: uv run sync_fw_json.py | tee "$RUNNER_TEMP/sync-summary.md"
+
+      - name: Validate updated sdcard.json
+        run: uv run validate_sdcard_json.py
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(sdcard.json): sync target list with edgetx/edgetx fw.json"
+          branch: chore/sync-fw-json
+          delete-branch: true
+          title: "chore(sdcard.json): sync target list with edgetx/edgetx fw.json"
+          body-path: ${{ runner.temp }}/sync-summary.md
+          add-paths: sdcard.json

--- a/.github/workflows/validate_sdcard_json.yml
+++ b/.github/workflows/validate_sdcard_json.yml
@@ -1,0 +1,30 @@
+name: Validate sdcard.json
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+    paths:
+      - 'sdcard.json'
+      - 'sdcard/**'
+      - 'validate_sdcard_json.py'
+      - 'sdcard_json_utils.py'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sdcard.json'
+      - 'sdcard/**'
+      - 'validate_sdcard_json.py'
+      - 'sdcard_json_utils.py'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+      - name: Validate sdcard.json
+        run: uv run validate_sdcard_json.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,13 @@ uv run ruff format .
 
 `generate.py`'s logic lives in plain, independently testable functions (variant extraction, directory merging, zip building) — see `tests/test_generate.py` for examples. When changing its behavior, add or update a test alongside the change.
 
+## Keeping sdcard.json in sync with EdgeTX/edgetx
+
+`sdcard.json` mirrors the target list in [`fw.json`](https://github.com/EdgeTX/edgetx/blob/main/fw.json) from `EdgeTX/edgetx`, plus a screen resolution per target that `fw.json` doesn't carry.
+
+- `validate_sdcard_json.py` checks `sdcard.json`'s syntax, schema, alphabetical order, and that every referenced resolution has a matching `sdcard/<resolution>/` directory. It runs in CI on every change to `sdcard.json`.
+- `sync_fw_json.py` fetches `fw.json` and the relevant `radio/src/boards/hw_defs/<flavour>.json` files from `EdgeTX/edgetx` and reconciles `sdcard.json` against them — additions, removals, renames, and resolution corrections. It runs weekly and opens a PR when it finds drift; run it locally with `uv run sync_fw_json.py` to check on demand. A target it can't resolve a screen size for is left alone and reported as a warning rather than guessed at — that still needs a human.
+
 ## Working with symlinks
 
 See the [README](README.md#for-developers) for details on the symlink layout used to avoid duplicating shared template files across screen sizes, and the Windows sync-script fallback for environments without symlink support.

--- a/sdcard_json_utils.py
+++ b/sdcard_json_utils.py
@@ -1,0 +1,10 @@
+"""Helpers shared by validate_sdcard_json.py and sync_fw_json.py."""
+
+import re
+
+RESOLUTION_RE = re.compile(r"^(bw|c)\d+x\d+$")
+
+
+def natural_sort_key(name: str) -> list[int | str]:
+    """Split a string into text/number chunks so digit runs compare numerically."""
+    return [int(chunk) if chunk.isdigit() else chunk.lower() for chunk in re.split(r"(\d+)", name)]

--- a/sync_fw_json.py
+++ b/sync_fw_json.py
@@ -1,0 +1,153 @@
+"""Reconcile sdcard.json against EdgeTX/edgetx's fw.json.
+
+fw.json only carries [name, prefix] pairs, no screen resolution, so for
+every target this also fetches radio/src/boards/hw_defs/<flavour>.json
+and derives "bw<W>x<H>" / "c<W>x<H>" from lcd_w/lcd_h/lcd_depth - the
+same hardware description the firmware build itself uses. That covers
+new targets, renames, removed targets, and resolution drift on existing
+entries (this is what would have caught the HelloRadioSky V12 mistake
+automatically: it was hand-entered as bw128x64, but its PCB is actually
+colorlcd 320x240).
+
+Rewrites sdcard.json in place if anything changed and prints a summary
+of what changed to stdout for the calling workflow to use as a PR body.
+Exits non-zero only on a hard failure to fetch fw.json itself - a
+per-target hw_defs lookup failure just leaves that entry untouched and
+is reported instead of guessed at.
+"""
+
+import functools
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from sdcard_json_utils import natural_sort_key
+
+IN_CI = bool(os.environ.get("GITHUB_ACTIONS"))
+
+EDGETX_RAW = "https://raw.githubusercontent.com/EdgeTX/edgetx/main"
+FW_JSON_URL = f"{EDGETX_RAW}/fw.json"
+HW_DEF_URL = f"{EDGETX_RAW}/radio/src/boards/hw_defs/{{flavour}}.json"
+
+# fw.json prefixes that don't map 1:1 onto their hw_defs/<flavour>.json
+# filename. See tools/boards.py and the PCBREV branches in
+# targets/taranis/CMakeLists.txt (EdgeTX/edgetx) for how PCBREV picks
+# FLAVOUR - HW_DESC_JSON is "${FLAVOUR}.json", not the fw.json prefix.
+PREFIX_TO_FLAVOUR_OVERRIDES = {
+    "x9dp2019": "x9d+2019",
+}
+
+
+@functools.cache
+def fetch_json(url: str) -> dict | list | None:
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError, ValueError) as e:
+        print(f"warning: failed to fetch {url}: {e}", file=sys.stderr)
+        return None
+
+
+def resolution_for_prefix(prefix: str) -> str | None:
+    flavour_key = prefix.rstrip("-")
+    flavour = PREFIX_TO_FLAVOUR_OVERRIDES.get(flavour_key, flavour_key)
+    hw_def = fetch_json(HW_DEF_URL.format(flavour=flavour))
+    if hw_def is None:
+        return None
+    try:
+        display = hw_def["display"]
+        width, height, depth = display["lcd_w"], display["lcd_h"], display["lcd_depth"]
+    except (KeyError, TypeError):
+        return None
+    kind = "bw" if depth <= 4 else "c"
+    return f"{kind}{width}x{height}"
+
+
+def reconcile(
+    sdcard_targets: list[list[str]],
+    fw_targets: list[list[str]],
+    resolve_resolution=resolution_for_prefix,
+) -> tuple[list[list[str]], list[str], list[str]]:
+    """Return (new sdcard.json targets, content changes for the PR body, warnings to surface regardless)."""
+    by_prefix = {prefix: (name, prefix, resolution) for name, prefix, resolution in sdcard_targets}
+    fw_prefixes = {prefix for _name, prefix in fw_targets}
+
+    changes: list[str] = []
+    warnings: list[str] = []
+    result: list[list[str]] = []
+
+    for fw_name, fw_prefix in fw_targets:
+        existing = by_prefix.get(fw_prefix)
+        resolution = resolve_resolution(fw_prefix)
+
+        if existing is None:
+            if resolution is None:
+                warnings.append(
+                    f'new target "{fw_name}" ({fw_prefix}) skipped - could not determine '
+                    "screen resolution from hw_defs, needs manual review"
+                )
+                continue
+            result.append([fw_name, fw_prefix, resolution])
+            changes.append(f'- Added "{fw_name}" ({fw_prefix}) as {resolution}')
+            continue
+
+        existing_name, _existing_prefix, existing_resolution = existing
+        new_resolution = resolution if resolution is not None else existing_resolution
+
+        if resolution is None:
+            warnings.append(f'could not verify resolution for "{fw_name}" ({fw_prefix}), keeping {existing_resolution}')
+        if fw_name != existing_name:
+            changes.append(f'- Renamed "{existing_name}" -> "{fw_name}" ({fw_prefix})')
+        if new_resolution != existing_resolution:
+            changes.append(f'- Fixed "{fw_name}" ({fw_prefix}) resolution: {existing_resolution} -> {new_resolution}')
+
+        result.append([fw_name, fw_prefix, new_resolution])
+
+    for existing_name, existing_prefix, _existing_resolution in sdcard_targets:
+        if existing_prefix not in fw_prefixes:
+            changes.append(f'- Removed "{existing_name}" ({existing_prefix}) - no longer in fw.json')
+
+    result.sort(key=lambda t: natural_sort_key(t[0]))
+    return result, changes, warnings
+
+
+def format_sdcard_json(targets: list[list[str]]) -> str:
+    lines = ["{", '  "targets": [']
+    for i, target in enumerate(targets):
+        comma = "," if i < len(targets) - 1 else ""
+        lines.append(f"    {json.dumps(target)}{comma}")
+    lines.append("  ]")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    sdcard_json_path = Path.cwd() / "sdcard.json"
+    sdcard_targets = json.loads(sdcard_json_path.read_text())["targets"]
+
+    fw_data = fetch_json(FW_JSON_URL)
+    if fw_data is None:
+        print("::error::could not fetch fw.json from EdgeTX/edgetx", file=sys.stderr)
+        return 1
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, fw_data["targets"])
+
+    for warning in warnings:
+        print(f"::warning::{warning}" if IN_CI else f"WARNING: {warning}", file=sys.stderr)
+
+    if not changes:
+        print("sdcard.json is already in sync with fw.json")
+        return 0
+
+    sdcard_json_path.write_text(format_sdcard_json(new_targets))
+
+    print("sdcard.json updated:\n")
+    print("\n".join(changes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sync_fw_json.py
+++ b/tests/test_sync_fw_json.py
@@ -1,0 +1,96 @@
+from sync_fw_json import format_sdcard_json, reconcile
+
+
+def resolver(resolutions: dict[str, str | None]):
+    return lambda prefix: resolutions.get(prefix)
+
+
+def test_reconcile_reports_no_changes_when_already_in_sync() -> None:
+    sdcard_targets = [["Device A", "a-", "c480x272"]]
+    fw_targets = [["Device A", "a-"]]
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, fw_targets, resolver({"a-": "c480x272"}))
+
+    assert new_targets == sdcard_targets
+    assert changes == []
+    assert warnings == []
+
+
+def test_reconcile_adds_new_target_with_derived_resolution() -> None:
+    new_targets, changes, warnings = reconcile([], [["Device A", "a-"]], resolver({"a-": "c480x272"}))
+
+    assert new_targets == [["Device A", "a-", "c480x272"]]
+    assert "Added" in changes[0]
+    assert "c480x272" in changes[0]
+    assert warnings == []
+
+
+def test_reconcile_warns_and_skips_new_target_when_resolution_unknown() -> None:
+    new_targets, changes, warnings = reconcile([], [["Device A", "a-"]], resolver({}))
+
+    assert new_targets == []
+    assert changes == []
+    assert "skipped" in warnings[0]
+
+
+def test_reconcile_removes_target_missing_from_fw_json() -> None:
+    sdcard_targets = [["Device A", "a-", "c480x272"]]
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, [], resolver({}))
+
+    assert new_targets == []
+    assert "Removed" in changes[0]
+    assert "Device A" in changes[0]
+    assert warnings == []
+
+
+def test_reconcile_fixes_drifted_resolution_on_existing_target() -> None:
+    sdcard_targets = [["HelloRadioSky V12", "v12-", "bw128x64"]]
+    fw_targets = [["HelloRadioSky V12", "v12-"]]
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, fw_targets, resolver({"v12-": "c320x240"}))
+
+    assert new_targets == [["HelloRadioSky V12", "v12-", "c320x240"]]
+    assert any("bw128x64 -> c320x240" in c for c in changes)
+    assert warnings == []
+
+
+def test_reconcile_renames_target_keeping_its_resolution() -> None:
+    sdcard_targets = [["Old Name", "a-", "c480x272"]]
+    fw_targets = [["New Name", "a-"]]
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, fw_targets, resolver({"a-": "c480x272"}))
+
+    assert new_targets == [["New Name", "a-", "c480x272"]]
+    assert any("Old Name" in c and "New Name" in c for c in changes)
+    assert warnings == []
+
+
+def test_reconcile_keeps_existing_resolution_and_warns_when_lookup_fails() -> None:
+    sdcard_targets = [["Device A", "a-", "c480x272"]]
+    fw_targets = [["Device A", "a-"]]
+
+    new_targets, changes, warnings = reconcile(sdcard_targets, fw_targets, resolver({}))
+
+    assert new_targets == [["Device A", "a-", "c480x272"]]
+    assert changes == []
+    assert "could not verify" in warnings[0]
+
+
+def test_reconcile_sorts_result_naturally_by_name() -> None:
+    fw_targets = [["Device B2", "b2-"], ["Device A", "a-"], ["Device B10", "b10-"]]
+    resolutions = {"a-": "c480x272", "b2-": "c480x272", "b10-": "c480x272"}
+
+    new_targets, _changes, _warnings = reconcile([], fw_targets, resolver(resolutions))
+
+    assert [t[0] for t in new_targets] == ["Device A", "Device B2", "Device B10"]
+
+
+def test_format_sdcard_json_matches_repo_style() -> None:
+    targets = [["Device A", "a-", "c480x272"], ["Device B", "b-", "bw128x64"]]
+
+    output = format_sdcard_json(targets)
+
+    assert output == (
+        '{\n  "targets": [\n    ["Device A", "a-", "c480x272"],\n    ["Device B", "b-", "bw128x64"]\n  ]\n}\n'
+    )

--- a/tests/test_validate_sdcard_json.py
+++ b/tests/test_validate_sdcard_json.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from validate_sdcard_json import validate_order, validate_schema, validate_variant_dirs
+
+
+def test_validate_schema_accepts_well_formed_targets() -> None:
+    data = {"targets": [["Device A", "a-", "c480x272"], ["Device B", "b-", "bw128x64"]]}
+
+    assert validate_schema(data) == []
+
+
+def test_validate_schema_rejects_extra_top_level_keys() -> None:
+    data = {"targets": [], "changelog": "hi"}
+
+    assert validate_schema(data) != []
+
+
+def test_validate_schema_rejects_bad_prefix_and_resolution() -> None:
+    data = {"targets": [["Device A", "a", "480x272"]]}
+
+    errors = validate_schema(data)
+
+    assert any("prefix" in e for e in errors)
+    assert any("resolution" in e for e in errors)
+
+
+def test_validate_order_passes_for_sorted_names() -> None:
+    targets = [["Device A", "a-", "c480x272"], ["Device B2", "b2-", "c480x272"], ["Device B10", "b10-", "c480x272"]]
+
+    assert validate_order(targets) == []
+
+
+def test_validate_order_flags_out_of_order_names() -> None:
+    targets = [["Device B", "b-", "c480x272"], ["Device A", "a-", "c480x272"]]
+
+    errors = validate_order(targets)
+
+    assert len(errors) == 1
+    assert "Device B" in errors[0]
+
+
+def test_validate_variant_dirs_flags_missing_directory(tmp_path: Path) -> None:
+    sdcard_dir = tmp_path / "sdcard"
+    (sdcard_dir / "c480x272").mkdir(parents=True)
+    targets = [["Device A", "a-", "c480x272"], ["Device B", "b-", "bw128x64"]]
+
+    errors = validate_variant_dirs(targets, sdcard_dir)
+
+    assert len(errors) == 1
+    assert "bw128x64" in errors[0]

--- a/validate_sdcard_json.py
+++ b/validate_sdcard_json.py
@@ -1,0 +1,95 @@
+"""Validate sdcard.json: syntax, schema, alphabetical order, and variant directories."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from sdcard_json_utils import RESOLUTION_RE, natural_sort_key
+
+IN_CI = bool(os.environ.get("GITHUB_ACTIONS"))
+
+
+def error_msg(message: str) -> None:
+    print(f"::error::{message}" if IN_CI else f"ERROR: {message}")
+
+
+def validate_schema(data: object) -> list[str]:
+    if not isinstance(data, dict) or set(data.keys()) != {"targets"}:
+        return ['sdcard.json must be an object with a single "targets" key']
+
+    targets = data["targets"]
+    if not isinstance(targets, list):
+        return ['"targets" must be an array']
+
+    errors = []
+    for i, target in enumerate(targets, start=1):
+        if not (isinstance(target, list) and len(target) == 3):
+            errors.append(f"target {i} must be a [name, prefix, resolution] array")
+            continue
+        name, prefix, resolution = target
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"target {i} name must be a non-empty string")
+            name = f"#{i}"
+        if not isinstance(prefix, str) or not prefix.strip() or not prefix.endswith("-"):
+            errors.append(f"target {i} ({name!r}) prefix must be a non-empty string ending in '-'")
+        if not isinstance(resolution, str) or not RESOLUTION_RE.match(resolution):
+            errors.append(f"target {i} ({name!r}) resolution {resolution!r} must match bw<W>x<H> or c<W>x<H>")
+    return errors
+
+
+def validate_order(targets: list[list[str]]) -> list[str]:
+    names = [t[0] for t in targets]
+    sorted_names = sorted(names, key=natural_sort_key)
+    for i, (actual, expected) in enumerate(zip(names, sorted_names)):
+        if actual != expected:
+            message = (
+                f"targets are not in natural alphabetical order: {actual!r} at position {i + 1} "
+                f"should come after {expected!r}"
+            )
+            return [message]
+    return []
+
+
+def validate_variant_dirs(targets: list[list[str]], sdcard_dir: Path) -> list[str]:
+    resolutions = sorted({t[2] for t in targets})
+    return [
+        f'target resolution "{resolution}" has no matching sdcard/{resolution}/ directory'
+        for resolution in resolutions
+        if not (sdcard_dir / resolution).is_dir()
+    ]
+
+
+def main() -> int:
+    root = Path.cwd()
+    sdcard_json_path = root / "sdcard.json"
+    sdcard_dir = root / "sdcard"
+
+    try:
+        data = json.loads(sdcard_json_path.read_text())
+    except FileNotFoundError:
+        error_msg("sdcard.json not found")
+        return 1
+    except json.JSONDecodeError as e:
+        error_msg(f"sdcard.json is not valid JSON: {e}")
+        return 1
+
+    errors = validate_schema(data)
+    if errors:
+        for e in errors:
+            error_msg(e)
+        return 1
+
+    targets = data["targets"]
+    errors = validate_order(targets) + validate_variant_dirs(targets, sdcard_dir)
+    if errors:
+        for e in errors:
+            error_msg(e)
+        return 1
+
+    print(f"sdcard.json OK: {len(targets)} targets validated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to #292. `sdcard.json` mirrors `EdgeTX/edgetx`'s [`fw.json`](https://github.com/EdgeTX/edgetx/blob/main/fw.json), plus a per-target screen resolution that `fw.json` doesn't carry — that gap is exactly how it drifted (and how HelloRadioSky V12 ended up mislabeled as `bw128x64` instead of `c320x240`). This adds automation so it can't silently drift again.

- **`sync_fw_json.py`** fetches `fw.json` plus the relevant `radio/src/boards/hw_defs/<flavour>.json` files from `EdgeTX/edgetx` and derives each target's resolution from `lcd_w`/`lcd_h`/`lcd_depth` — the same hardware description the firmware build itself uses, rather than a human eyeballing `BITMAPS_DIR` (which for GX15/T22 doesn't actually match their true LCD resolution). It reconciles additions, removals, renames, and resolution drift on *existing* entries too — this logic reproduces the V12 fix and the four target additions from #292 entirely on its own (verified locally against the live repo). A target whose resolution it can't determine is left untouched and reported as a warning rather than guessed at.
  - Wired into `.github/workflows/sync_fw_json.yml` on a weekly schedule + `workflow_dispatch`, opening/updating a PR via `create-pull-request` — a human still reviews before merge, since a genuinely new resolution needs real template content in `sdcard/`, which `generate.py`'s existing "missing variant directory" check still guards.
- **`validate_sdcard_json.py`** checks `sdcard.json`'s syntax, schema (`[name, prefix, resolution]`), natural alphabetical order, and that every resolution has a matching `sdcard/<resolution>/` directory — modeled on `EdgeTX/edgetx`'s own `validate_fw_json.yml`/`validate-json.py`. Wired into `.github/workflows/validate_sdcard_json.yml` on every push/PR touching `sdcard.json`, so it also covers the sync workflow's own PRs.
- `sdcard_json_utils.py` holds the natural-sort-key and resolution-regex logic shared by both scripts.

No changes needed in `EdgeTX/edgetx` and no secrets/PATs required — everything reads `fw.json`/`hw_defs/*.json` over plain `raw.githubusercontent.com` and only ever writes to this repo.

## Test plan
- [x] `uv run pytest` — 21 tests pass, including new coverage for both scripts
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `format_sdcard_json()` output verified byte-identical to the real `sdcard.json`'s current formatting (round-trip, no spurious diffs on a no-op run)
- [x] Ran `sync_fw_json.py` live against `EdgeTX/edgetx` — correctly reports "already in sync" post-#292
- [x] Deliberately reverted the V12 fix + removed GX15 locally, reran `sync_fw_json.py` live — it re-derived both correctly and reproduced the exact #292 diff
- [x] Both new workflow YAML files parse cleanly