### PR TITLE
chore: RadioMaster TX16S, add TX16S Mark II to display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A non-exhaustive list of targets (look at the [sdcard.json](https://github.com/E
     - FrSky Horus x12s
     - Jumper T16
     - Jumper T18
-    - RadioMaster TX16s / TX16s mkII
+    - RadioMaster TX16S / TX16S Mark II
 - **c480x320.zip** (480x320 pixel, landscape orientation)
     - Flysky PL18
     - Flysky Paladin EV (PL18EV)

--- a/sdcard.json
+++ b/sdcard.json
@@ -40,7 +40,7 @@
     ["RadioMaster Pocket", "pocket-", "bw128x64"],
     ["RadioMaster TX12MK2", "tx12mk2-", "bw128x64"],
     ["RadioMaster TX15", "tx15-", "c480x320"],
-    ["RadioMaster TX16S", "tx16s-", "c480x272"],
+    ["RadioMaster TX16S / TX16S Mark II", "tx16s-", "c480x272"],
     ["RadioMaster TX16S MK3", "tx16smk3-", "c800x480"],
     ["RadioMaster Zorro", "zorro-", "bw128x64"]
   ]


### PR DESCRIPTION
## Summary
- The TX16S and TX16S Mark II share the same `tx16s-` firmware/SD-card target, but `sdcard.json` and the README only mentioned the TX16S.
- Updates the label in `sdcard.json` to `RadioMaster TX16S / TX16S Mark II`, matching RadioMaster's actual product branding (and the corresponding fix in the edgetx repo's bug report issue template).
- Fixes README.md to match: `RadioMaster TX16s / TX16s mkII` → `RadioMaster TX16S / TX16S Mark II`.
- Display-label-only change — no functional impact, matching logic uses the `tx16s-` prefix, not this string.

## Test plan
- [x] `sdcard.json` re-validated as valid JSON after the edit.
- [x] Confirmed no code paths key off this display string (only the `tx16s-` prefix is used for matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)